### PR TITLE
fix: cap embedding batch size for OpenAI-compatible providers (#33)

### DIFF
--- a/hyperextract/utils/client.py
+++ b/hyperextract/utils/client.py
@@ -62,7 +62,8 @@ class CompatibleEmbeddings(Embeddings):
         model: str = "text-embedding-ada-002",
         api_key: Optional[str] = None,
         base_url: Optional[str] = None,
-        chunk_size: int = 1000,
+        max_batch_size: int = 10,
+        chunk_size: Optional[int] = None,
         max_retries: int = 2,
         **kwargs: Any,
     ):
@@ -74,7 +75,12 @@ class CompatibleEmbeddings(Embeddings):
             max_retries=max_retries,
         )
         self._model = model
-        self._chunk_size = chunk_size
+
+        # max_batch_size caps how many inputs are sent per embeddings request.
+        # Many OpenAI-compatible providers reject large batches (e.g. Bailian /
+        # DashScope caps at 10), so the default is intentionally conservative.
+        # `chunk_size` is the legacy name for this knob and is kept as an alias.
+        self._max_batch_size = chunk_size if chunk_size is not None else max_batch_size
 
         # Determine the tiktoken encoding to use for chunking
         import tiktoken
@@ -119,7 +125,7 @@ class CompatibleEmbeddings(Embeddings):
         if not chunks:
             return []
 
-        # Group chunks into batches of chunk_size
+        # Group chunks into batches no larger than max_batch_size
         all_embeddings: List[Optional[List[float]]] = [None] * len(texts)
         batch: List[Tuple[str, int]] = []
 
@@ -141,7 +147,7 @@ class CompatibleEmbeddings(Embeddings):
 
         for chunk in chunks:
             batch.append(chunk)
-            if len(batch) >= self._chunk_size:
+            if len(batch) >= self._max_batch_size:
                 _embed_batch(batch)
                 batch = []
 

--- a/tests/utils/test_client.py
+++ b/tests/utils/test_client.py
@@ -260,6 +260,52 @@ class TestCompatibleEmbeddings:
             # Should have been called twice due to chunk_size=1
             assert mock_openai_client.embeddings.create.call_count == 2
 
+    def test_max_batch_size_splits_requests(self, mock_openai_client):
+        """Inputs are split so no request exceeds max_batch_size (issue #33).
+
+        Providers like Bailian/DashScope reject batches larger than 10. With
+        25 inputs and max_batch_size=10, embed_documents must issue 3 requests
+        (10 + 10 + 5) and never send more than 10 inputs in a single call.
+        """
+        emb = CompatibleEmbeddings(
+            model="test-model",
+            api_key="sk-test",
+            base_url="http://test/v1",
+            max_batch_size=10,
+        )
+
+        def fake_create(input, model):
+            # Echo back one embedding per input so indexing stays aligned.
+            return MagicMock(data=[MagicMock(embedding=[0.1, 0.2]) for _ in input])
+
+        mock_openai_client.embeddings.create.side_effect = fake_create
+        with patch.object(emb, "_client", mock_openai_client):
+            result = emb.embed_documents([f"text-{i}" for i in range(25)])
+
+        assert len(result) == 25
+        assert mock_openai_client.embeddings.create.call_count == 3
+        for call in mock_openai_client.embeddings.create.call_args_list:
+            assert len(call.kwargs["input"]) <= 10
+
+    def test_default_batch_size_is_conservative(self):
+        """Default max_batch_size stays within the strictest known provider cap."""
+        emb = CompatibleEmbeddings(
+            model="test-model",
+            api_key="sk-test",
+            base_url="http://test/v1",
+        )
+        assert emb._max_batch_size <= 10
+
+    def test_chunk_size_alias_back_compat(self):
+        """Legacy `chunk_size` keyword still controls the batch size."""
+        emb = CompatibleEmbeddings(
+            model="test-model",
+            api_key="sk-test",
+            base_url="http://test/v1",
+            chunk_size=5,
+        )
+        assert emb._max_batch_size == 5
+
 
 # =============================================================================
 # get_client (config file)


### PR DESCRIPTION
Fixes #33.

## Problem
`he parse` crashes with `400 InvalidParameter: batch size ... should not be larger than 10` on OpenAI-compatible providers such as Bailian/DashScope. `CompatibleEmbeddings` sent up to 1000 inputs per embeddings request, exceeding the provider's batch cap.

## Fix
- Add `max_batch_size` (default 10) to `CompatibleEmbeddings` and cap each `embeddings.create` request by it. Safe default: this class is only used for non-OpenAI providers; official OpenAI still uses `OpenAIEmbeddings`.
- Keep the legacy `chunk_size` keyword as a backward-compatible alias.

## Tests
- 25 inputs with `max_batch_size=10` now issue 3 requests, none exceeding 10 inputs.
- Conservative default and `chunk_size` alias covered.
- Full suite: 238 passed.