### PR TITLE
fix: use true mean when averaging multi-chunk embeddings

### DIFF
--- a/hyperextract/utils/client.py
+++ b/hyperextract/utils/client.py
@@ -147,9 +147,7 @@ class CompatibleEmbeddings(Embeddings):
                     counts[orig_idx] = 1
                 else:
                     running = sums[orig_idx]
-                    sums[orig_idx] = [
-                        a + b for a, b in zip(running, emb, strict=False)
-                    ]
+                    sums[orig_idx] = [a + b for a, b in zip(running, emb, strict=False)]
                     counts[orig_idx] += 1
 
         for chunk in chunks:

--- a/hyperextract/utils/client.py
+++ b/hyperextract/utils/client.py
@@ -129,21 +129,28 @@ class CompatibleEmbeddings(Embeddings):
         all_embeddings: List[Optional[List[float]]] = [None] * len(texts)
         batch: List[Tuple[str, int]] = []
 
+        # Accumulate a running sum and count per text so multi-chunk texts get a
+        # true mean. A pairwise (prev + curr) / 2 only yields the mean for two
+        # chunks; for three or more it biases toward later chunks.
+        sums: Dict[int, List[float]] = {}
+        counts: Dict[int, int] = {}
+
         def _embed_batch(b: List[Tuple[str, int]]) -> None:
             response = self._client.embeddings.create(
                 input=[text for text, _ in b],
                 model=self._model,
             )
             for (text, orig_idx), emb_data in zip(b, response.data, strict=False):
-                if all_embeddings[orig_idx] is None:
-                    all_embeddings[orig_idx] = emb_data.embedding
+                emb = emb_data.embedding
+                if orig_idx not in sums:
+                    sums[orig_idx] = list(emb)
+                    counts[orig_idx] = 1
                 else:
-                    # Average embeddings for multi-chunk texts
-                    prev = all_embeddings[orig_idx]
-                    curr = emb_data.embedding
-                    all_embeddings[orig_idx] = [
-                        (a + b) / 2 for a, b in zip(prev, curr, strict=False)
+                    running = sums[orig_idx]
+                    sums[orig_idx] = [
+                        a + b for a, b in zip(running, emb, strict=False)
                     ]
+                    counts[orig_idx] += 1
 
         for chunk in chunks:
             batch.append(chunk)
@@ -153,6 +160,11 @@ class CompatibleEmbeddings(Embeddings):
 
         if batch:
             _embed_batch(batch)
+
+        # Divide each running sum by its chunk count to get the mean embedding.
+        for orig_idx, running in sums.items():
+            count = counts[orig_idx]
+            all_embeddings[orig_idx] = [v / count for v in running]
 
         # Fill in any missing embeddings with empty-string embedding
         missing_indices = [i for i, e in enumerate(all_embeddings) if e is None]

--- a/tests/utils/test_client.py
+++ b/tests/utils/test_client.py
@@ -306,6 +306,47 @@ class TestCompatibleEmbeddings:
         )
         assert emb._max_batch_size == 5
 
+    def test_multichunk_uses_true_mean(self, mock_openai_client):
+        """A text split into 3+ chunks is reduced to the true mean embedding.
+
+        The old pairwise (prev + curr) / 2 produced [6.75, ...] for chunk
+        vectors 3/6/9; the correct mean is (3 + 6 + 9) / 3 = 6.
+        """
+        emb = CompatibleEmbeddings(
+            model="test-model",
+            api_key="sk-test",
+            base_url="http://test/v1",
+        )
+        mock_openai_client.embeddings.create.return_value = MagicMock(
+            data=[
+                MagicMock(embedding=[3.0, 3.0, 3.0]),
+                MagicMock(embedding=[6.0, 6.0, 6.0]),
+                MagicMock(embedding=[9.0, 9.0, 9.0]),
+            ]
+        )
+        # Force the single input text to split into three chunks.
+        with patch.object(
+            emb, "_split_texts", return_value=[("c1", 0), ("c2", 0), ("c3", 0)]
+        ), patch.object(emb, "_client", mock_openai_client):
+            result = emb.embed_documents(["a long text"])
+
+        assert result == [[6.0, 6.0, 6.0]]
+
+    def test_single_chunk_embedding_unchanged(self, mock_openai_client):
+        """A single-chunk text returns its embedding unchanged (regression guard)."""
+        emb = CompatibleEmbeddings(
+            model="test-model",
+            api_key="sk-test",
+            base_url="http://test/v1",
+        )
+        mock_openai_client.embeddings.create.return_value = MagicMock(
+            data=[MagicMock(embedding=[0.1, 0.2, 0.3])]
+        )
+        with patch.object(emb, "_client", mock_openai_client):
+            result = emb.embed_documents(["hi"])
+
+        assert result == [[0.1, 0.2, 0.3]]
+
 
 # =============================================================================
 # get_client (config file)


### PR DESCRIPTION
## Problem
When a long text is split into multiple chunks, `CompatibleEmbeddings.embed_documents` combined the chunk embeddings with a running `(prev + curr) / 2`. That equals the mean only for two chunks; for three or more it biases toward later chunks (e.g. chunks 3/6/9 yield 6.75 instead of the correct mean 6), degrading embedding and search quality for long documents.

## Fix
Accumulate a running sum and count per text, then divide once at the end to produce the true mean. Single-chunk texts are unaffected.

## Tests
- 3-chunk text now reduces to the correct mean `[6, 6, 6]` (old code produced `[6.75, ...]`).
- Single-chunk text returns its embedding unchanged (regression guard).
- Full client suite: 35 passed.