### PR TITLE
feat: add Obsidian vault export for knowledge graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Hyper-Extract is an intelligent, LLM-powered knowledge extraction and evolution 
 | 🧠 **10+ Extraction Engines** | GraphRAG, LightRAG, Hyper-RAG, KG-Gen, and more — ready to use |
 | 📝 **80+ YAML Templates** | Zero-code extraction across Finance, Legal, Medical, TCM, Industry, and General domains |
 | 🔄 **Incremental Evolution** | Feed new documents anytime to expand and refine your knowledge base |
+| 📤 **Obsidian Export** | Turn any extracted graph into an Obsidian vault — Markdown notes linked by `[[wikilinks]]` |
 
 ## 🎯 What Can You Do With It?
 
@@ -122,6 +123,9 @@ he search ./output/ "What are Tesla's major achievements?"
 
 # Visualize
 he show ./output/
+
+# Export to an Obsidian vault (Markdown notes + [[wikilinks]])
+he export ./output/ -o ./vault/
 ```
 
 <details>

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ he search ./output/ "What are Tesla's major achievements?"
 he show ./output/
 
 # Export to an Obsidian vault (Markdown notes + [[wikilinks]])
-he export ./output/ -o ./vault/
+he export obsidian ./output/ -o ./vault/
 ```
 
 <details>

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -45,6 +45,7 @@ Hyper-Extract 是一个智能的、由大语言模型（LLM）驱动的知识提
 | 🧠 **10+ 提取引擎** | GraphRAG、LightRAG、Hyper-RAG、KG-Gen 等开箱即用 |
 | 📝 **80+ YAML 模板** | 零代码提取，覆盖金融、法律、医疗、中医、工业、通用 6 大领域 |
 | 🔄 **增量演进** | 随时喂入新文档，自动扩展和精炼知识库 |
+| 📤 **Obsidian 导出** | 将提取的图谱导出为 Obsidian 知识库——以 `[[双向链接]]` 关联的 Markdown 笔记 |
 
 ## 🎯 它能做什么？
 
@@ -122,6 +123,9 @@ he search ./output/ "苏轼有哪些重要的作品？"
 
 # 可视化
 he show ./output/
+
+# 导出为 Obsidian 知识库（Markdown 笔记 + [[双向链接]]）
+he export ./output/ -o ./vault/
 ```
 
 <details>

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -125,7 +125,7 @@ he search ./output/ "苏轼有哪些重要的作品？"
 he show ./output/
 
 # 导出为 Obsidian 知识库（Markdown 笔记 + [[双向链接]]）
-he export ./output/ -o ./vault/
+he export obsidian ./output/ -o ./vault/
 ```
 
 <details>

--- a/docs/en/cli/commands/export.md
+++ b/docs/en/cli/commands/export.md
@@ -1,0 +1,140 @@
+# he export obsidian
+
+Export a knowledge abstract to an [Obsidian](https://obsidian.md) vault — a folder of Markdown notes linked by `[[wikilinks]]`.
+
+`export` is a command group; `obsidian` is the format. (More formats may be added later.)
+
+---
+
+## Synopsis
+
+```bash
+he export obsidian KA_PATH -o VAULT_PATH [OPTIONS]
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `KA_PATH` | Path to the knowledge abstract directory (created by `he parse`) |
+
+## Options
+
+| Option | Alias | Default | Description |
+|--------|-------|---------|-------------|
+| `--output` | `-o` | *(required)* | Output vault directory |
+| `--name` | | output dir name | Vault name used for the index note |
+| `--no-index` | | off | Skip writing the index / map-of-content note |
+| `--force` | `-f` | off | Write into an existing, non-empty directory |
+
+---
+
+## Description
+
+`he export obsidian` turns an extracted knowledge graph into an Obsidian vault you can open and browse in Obsidian's interactive graph view:
+
+- **Each node → a Markdown note.** The node's fields are stored as YAML front-matter, followed by a `# Title` heading and (when present) a description.
+- **Each edge → a `[[wikilink]]`.** Relationships are rendered under the source note's `## Relationships` section, with the relationship label and description.
+- **An index note** (named after `--name`) lists every note grouped by type — a map-of-content for the vault.
+
+The exporter is dependency-free and writes plain Markdown, so the result is a normal Obsidian vault: open the folder via **"Open folder as vault"** in Obsidian, or re-ingest it later with [`he parse`](parse.md).
+
+---
+
+## Examples
+
+### Basic Usage
+
+```bash
+# Extract, then export
+he parse tesla.md -t general/biography_graph -o ./tesla_kb/ -l en
+he export obsidian ./tesla_kb/ -o ./tesla_vault/
+```
+
+### Custom Vault Name
+
+```bash
+he export obsidian ./tesla_kb/ -o ./tesla_vault/ --name "Tesla Knowledge Base"
+```
+
+### Overwrite an Existing Directory
+
+```bash
+he export obsidian ./tesla_kb/ -o ./tesla_vault/ --force
+```
+
+### Without the Index Note
+
+```bash
+he export obsidian ./tesla_kb/ -o ./tesla_vault/ --no-index
+```
+
+---
+
+## Output Structure
+
+```
+tesla_vault/
+├── Tesla Knowledge Base.md   # index (grouped by type)
+├── Nikola Tesla.md
+├── Alternating Current.md
+└── ...
+```
+
+A note looks like:
+
+```markdown
+---
+name: Nikola Tesla
+type: Person
+description: "Serbian-American inventor and electrical engineer"
+---
+
+# Nikola Tesla
+
+Serbian-American inventor and electrical engineer
+
+## Relationships
+
+- **developed** → [[Alternating Current]] — Pioneered the AC system.
+- **rivaled** → [[Thomas Edison]] — The War of the Currents.
+```
+
+Notes:
+
+- Filenames are sanitized for Obsidian/the filesystem; the original id/title is preserved as a front-matter `alias`, and wikilinks use a `[[stem|display]]` form so links always resolve.
+- Name collisions are de-duplicated (e.g. `Tesla coil (2)`).
+
+---
+
+## Supported Auto-Types
+
+Export works with the graph family:
+
+| Auto-Type | Export |
+|-----------|--------|
+| `AutoGraph` | ✓ one note per node, edges as wikilinks |
+| `AutoHypergraph` | ✓ N-ary edges link all members |
+| `AutoTemporalGraph` | ✓ (inherits `AutoGraph`) |
+| `AutoSpatialGraph` | ✓ (inherits `AutoGraph`) |
+| `AutoSpatioTemporalGraph` | ✓ (inherits `AutoGraph`) |
+
+Non-graph types (`AutoList`, `AutoSet`, `AutoModel`) are not supported; the command reports a clear error.
+
+---
+
+## Python API
+
+The same capability is available on graph Auto-Types:
+
+```python
+ka.export_obsidian("./tesla_vault/", vault_name="Tesla KB", overwrite=True)
+```
+
+---
+
+## See Also
+
+- [`he parse`](parse.md) — Extract knowledge (and ingest an existing vault folder)
+- [`he show`](show.md) — Visualize the graph with OntoSight
+- [`he info`](info.md) — View knowledge abstract statistics

--- a/docs/en/cli/index.md
+++ b/docs/en/cli/index.md
@@ -32,6 +32,7 @@ he --version
 |---------|---------|--------------|
 | `he parse` | Extract knowledge from documents | `-t` template, `-o` output, `-l` language |
 | `he show` | Visualize knowledge graph | — |
+| `he export obsidian` | Export to an Obsidian vault | `-o` output, `--name`, `-f` force |
 | `he search` | Semantic search in knowledge abstract | `-n` top-k results |
 | `he talk` | Chat with knowledge abstract | `-i` interactive, `-q` query |
 | `he feed` | Add documents incrementally | — |
@@ -148,6 +149,7 @@ he show ./output/
 - **[`he search`](commands/search.md)** — Semantic search
 - **[`he talk`](commands/talk.md)** — Chat with knowledge abstract
 - **[`he info`](commands/info.md)** — View knowledge abstract statistics
+- **[`he export obsidian`](commands/export.md)** — Export to an Obsidian vault
 
 ### Management
 

--- a/docs/zh/cli/commands/export.md
+++ b/docs/zh/cli/commands/export.md
@@ -1,0 +1,140 @@
+# he export obsidian
+
+将知识摘要导出为 [Obsidian](https://obsidian.md) 知识库——一个由 `[[双向链接]]` 关联的 Markdown 笔记文件夹。
+
+`export` 是一个命令组，`obsidian` 是格式（后续可能会增加更多格式）。
+
+---
+
+## 用法
+
+```bash
+he export obsidian KA_PATH -o VAULT_PATH [选项]
+```
+
+## 参数
+
+| 参数 | 说明 |
+|----------|-------------|
+| `KA_PATH` | 知识摘要目录路径（由 `he parse` 生成） |
+
+## 选项
+
+| 选项 | 别名 | 默认值 | 说明 |
+|--------|-------|---------|-------------|
+| `--output` | `-o` | *(必填)* | 输出知识库目录 |
+| `--name` | | 输出目录名 | 索引笔记使用的知识库名称 |
+| `--no-index` | | 关闭 | 跳过生成索引 / 目录笔记 |
+| `--force` | `-f` | 关闭 | 写入已存在且非空的目录 |
+
+---
+
+## 说明
+
+`he export obsidian` 将提取出的知识图谱转换为一个可在 Obsidian 图谱视图中浏览的知识库：
+
+- **每个节点 → 一篇 Markdown 笔记。** 节点字段写入 YAML front-matter，随后是 `# 标题` 以及（如有）描述。
+- **每条边 → 一个 `[[双向链接]]`。** 关系渲染在源笔记的 `## Relationships` 区块中，包含关系标签与描述。
+- **索引笔记**（以 `--name` 命名）按类型分组列出所有笔记，作为知识库目录。
+
+导出器无额外依赖，生成的是纯 Markdown，因此结果是一个标准 Obsidian 知识库：在 Obsidian 中用 **"Open folder as vault"** 打开该文件夹，或之后用 [`he parse`](parse.md) 重新导入。
+
+---
+
+## 示例
+
+### 基本用法
+
+```bash
+# 先提取，再导出
+he parse tesla.md -t general/biography_graph -o ./tesla_kb/ -l zh
+he export obsidian ./tesla_kb/ -o ./tesla_vault/
+```
+
+### 自定义知识库名称
+
+```bash
+he export obsidian ./tesla_kb/ -o ./tesla_vault/ --name "Tesla 知识库"
+```
+
+### 覆盖已存在目录
+
+```bash
+he export obsidian ./tesla_kb/ -o ./tesla_vault/ --force
+```
+
+### 不生成索引笔记
+
+```bash
+he export obsidian ./tesla_kb/ -o ./tesla_vault/ --no-index
+```
+
+---
+
+## 输出结构
+
+```
+tesla_vault/
+├── Tesla 知识库.md          # 索引（按类型分组）
+├── Nikola Tesla.md
+├── Alternating Current.md
+└── ...
+```
+
+一篇笔记的样子：
+
+```markdown
+---
+name: Nikola Tesla
+type: Person
+description: "Serbian-American inventor and electrical engineer"
+---
+
+# Nikola Tesla
+
+Serbian-American inventor and electrical engineer
+
+## Relationships
+
+- **developed** → [[Alternating Current]] — Pioneered the AC system.
+- **rivaled** → [[Thomas Edison]] — The War of the Currents.
+```
+
+说明：
+
+- 文件名会针对 Obsidian / 文件系统做净化；原始 id/标题保留为 front-matter 的 `alias`，双向链接使用 `[[stem|display]]` 形式以确保始终可解析。
+- 同名冲突会自动去重（例如 `Tesla coil (2)`）。
+
+---
+
+## 支持的 Auto-Type
+
+导出支持图谱家族：
+
+| Auto-Type | 导出 |
+|-----------|--------|
+| `AutoGraph` | ✓ 每个节点一篇笔记，边为双向链接 |
+| `AutoHypergraph` | ✓ N 元边链接所有成员 |
+| `AutoTemporalGraph` | ✓（继承自 `AutoGraph`） |
+| `AutoSpatialGraph` | ✓（继承自 `AutoGraph`） |
+| `AutoSpatioTemporalGraph` | ✓（继承自 `AutoGraph`） |
+
+非图谱类型（`AutoList`、`AutoSet`、`AutoModel`）不支持；命令会给出明确的错误提示。
+
+---
+
+## Python API
+
+图谱类 Auto-Type 也提供同样的能力：
+
+```python
+ka.export_obsidian("./tesla_vault/", vault_name="Tesla KB", overwrite=True)
+```
+
+---
+
+## 另请参阅
+
+- [`he parse`](parse.md) — 提取知识（也可导入已有的知识库文件夹）
+- [`he show`](show.md) — 使用 OntoSight 可视化图谱
+- [`he info`](info.md) — 查看知识摘要统计

--- a/docs/zh/cli/index.md
+++ b/docs/zh/cli/index.md
@@ -32,6 +32,7 @@ he --version
 |---------|---------|--------------|
 | `he parse` | 从文档提取知识 | `-t` 模板, `-o` 输出, `-l` 语言 |
 | `he show` | 可视化知识图谱 | — |
+| `he export obsidian` | 导出为 Obsidian 知识库 | `-o` 输出, `--name`, `-f` 强制 |
 | `he search` | 知识库语义搜索 | `-n` top-k 结果数 |
 | `he talk` | 与知识库对话 | `-i` 交互模式, `-q` 查询 |
 | `he feed` | 增量添加文档 | — |
@@ -148,6 +149,7 @@ he show ./output/
 - **[`he search`](commands/search.md)** — 语义搜索
 - **[`he talk`](commands/talk.md)** — 与知识库对话
 - **[`he info`](commands/info.md)** — 查看知识库统计信息
+- **[`he export obsidian`](commands/export.md)** — 导出为 Obsidian 知识库
 
 ### 管理
 

--- a/hyperextract/cli/cli.py
+++ b/hyperextract/cli/cli.py
@@ -136,6 +136,7 @@ def main(
                     ("he talk <ka_path> [-i]", "Chat with KA"),
                     ("he search <ka_path> <query>", "Semantic search"),
                     ("he show <ka_path>", "Visualize KA"),
+                    ("he export <ka_path> -o <vault>", "Export to Obsidian vault"),
                 ],
             ),
         ]
@@ -437,6 +438,88 @@ def show(ka_path: str = typer.Argument(..., help="Knowledge Abstract directory")
         f'[dim]  he search {ka_path} "keyword"  # Search specific content[/dim]'
     )
     console.print(f"[dim]  he talk {ka_path} -i           # Interactive chat[/dim]")
+
+
+@app.command(name="export")
+def export(
+    ka_path: str = typer.Argument(..., help="Knowledge Abstract directory"),
+    output: str = typer.Option(..., "--output", "-o", help="Output vault directory"),
+    fmt: str = typer.Option(
+        "obsidian", "--format", "-F", help="Export format (obsidian)"
+    ),
+    name: Optional[str] = typer.Option(
+        None, "--name", help="Vault name used for the index note"
+    ),
+    no_index: bool = typer.Option(
+        False, "--no-index", help="Skip writing the index/map-of-content note"
+    ),
+    force: bool = typer.Option(
+        False, "--force", "-f", help="Write into an existing, non-empty directory"
+    ),
+):
+    """Export a Knowledge Abstract to an Obsidian vault (Markdown + wikilinks)."""
+    logger.info("command=export ka_path=%s output=%s format=%s", ka_path, output, fmt)
+
+    if fmt != "obsidian":
+        console.print(
+            f"[red]Error:[/red] Unsupported format '{fmt}'. Supported: obsidian."
+        )
+        raise typer.Exit(1)
+
+    path = validate_ka_with_data(ka_path)
+    template, lang = get_template_from_ka(path)
+
+    output_path = Path(output)
+    if output_path.exists() and any(output_path.iterdir()) and not force:
+        console.print(
+            "[red]Error:[/red] Output directory already exists and is not empty. "
+            "Use --force to write into it."
+        )
+        raise typer.Exit(1)
+
+    console.print(f"[blue]Knowledge Abstract:[/blue] {ka_path}")
+    console.print(f"[blue]Template:[/blue] {template}")
+    console.print(f"[blue]Output vault:[/blue] {output}")
+    console.print()
+
+    validate_config()
+
+    vault_name = name or output_path.name or "Knowledge Vault"
+
+    with console.status("[bold blue]Loading Knowledge Abstract..."):
+        try:
+            ka = Template.create(template, lang)
+            ka.load(path)
+        except Exception as e:
+            console.print(f"[red]Error loading Knowledge Abstract:[/red] {e}")
+            raise typer.Exit(1)
+
+    if not hasattr(ka, "export_obsidian"):
+        console.print(
+            "[red]Error:[/red] Obsidian export is only supported for graph-type "
+            "Knowledge Abstracts (graph, hypergraph, temporal/spatial graphs)."
+        )
+        raise typer.Exit(1)
+
+    with console.status("[bold blue]Exporting to Obsidian vault..."):
+        try:
+            ka.export_obsidian(
+                output_path,
+                vault_name=vault_name,
+                include_index=not no_index,
+                overwrite=force,
+            )
+        except Exception as e:
+            console.print(f"[red]Error during export:[/red] {e}")
+            raise typer.Exit(1)
+
+    note_count = len(list(output_path.glob("*.md")))
+    console.print()
+    console.print(
+        f"[bold green]Success![/bold green] Exported {note_count} notes to {output_path}"
+    )
+    console.print()
+    console.print("[dim]Open the folder as a vault in Obsidian to explore it.[/dim]")
 
 
 @app.command(name="info")

--- a/hyperextract/cli/cli.py
+++ b/hyperextract/cli/cli.py
@@ -136,7 +136,10 @@ def main(
                     ("he talk <ka_path> [-i]", "Chat with KA"),
                     ("he search <ka_path> <query>", "Semantic search"),
                     ("he show <ka_path>", "Visualize KA"),
-                    ("he export <ka_path> -o <vault>", "Export to Obsidian vault"),
+                    (
+                        "he export obsidian <ka_path> -o <vault>",
+                        "Export to Obsidian vault",
+                    ),
                 ],
             ),
         ]
@@ -440,13 +443,17 @@ def show(ka_path: str = typer.Argument(..., help="Knowledge Abstract directory")
     console.print(f"[dim]  he talk {ka_path} -i           # Interactive chat[/dim]")
 
 
-@app.command(name="export")
-def export(
+export_app = typer.Typer(
+    name="export",
+    help="Export a Knowledge Abstract to other formats",
+    no_args_is_help=True,
+)
+
+
+@export_app.command(name="obsidian")
+def export_obsidian_cmd(
     ka_path: str = typer.Argument(..., help="Knowledge Abstract directory"),
     output: str = typer.Option(..., "--output", "-o", help="Output vault directory"),
-    fmt: str = typer.Option(
-        "obsidian", "--format", "-F", help="Export format (obsidian)"
-    ),
     name: Optional[str] = typer.Option(
         None, "--name", help="Vault name used for the index note"
     ),
@@ -458,13 +465,7 @@ def export(
     ),
 ):
     """Export a Knowledge Abstract to an Obsidian vault (Markdown + wikilinks)."""
-    logger.info("command=export ka_path=%s output=%s format=%s", ka_path, output, fmt)
-
-    if fmt != "obsidian":
-        console.print(
-            f"[red]Error:[/red] Unsupported format '{fmt}'. Supported: obsidian."
-        )
-        raise typer.Exit(1)
+    logger.info("command=export-obsidian ka_path=%s output=%s", ka_path, output)
 
     path = validate_ka_with_data(ka_path)
     template, lang = get_template_from_ka(path)
@@ -520,6 +521,9 @@ def export(
     )
     console.print()
     console.print("[dim]Open the folder as a vault in Obsidian to explore it.[/dim]")
+
+
+app.add_typer(export_app, name="export")
 
 
 @app.command(name="info")

--- a/hyperextract/types/graph.py
+++ b/hyperextract/types/graph.py
@@ -1045,3 +1045,55 @@ class AutoGraph(
             on_search=search_callback,
             on_chat=chat_callback,
         )
+
+    # ==================== Obsidian Export ====================
+
+    def export_obsidian(
+        self,
+        folder_path: str | Path,
+        *,
+        node_label_extractor: Callable[[NodeSchema], str] = None,
+        edge_label_extractor: Callable[[EdgeSchema], str] = None,
+        vault_name: str = "Knowledge Vault",
+        include_index: bool = True,
+        overwrite: bool = False,
+    ) -> Path:
+        """Export the graph as an Obsidian vault.
+
+        Writes one Markdown note per node (fields stored as YAML front-matter)
+        and renders every edge as an internal ``[[wikilink]]`` under its source
+        note. The resulting folder can be opened directly in Obsidian, where the
+        graph view reflects the extracted knowledge structure.
+
+        Args:
+            folder_path: Destination vault directory.
+            node_label_extractor: Optional node -> display title. Defaults to the
+                one from ``__init__``, then common fields, then the node id.
+            edge_label_extractor: Optional edge -> relationship label. Defaults to
+                the one from ``__init__``, then common fields, then "related to".
+            vault_name: Title used for the generated index note.
+            include_index: Whether to write an index/map-of-content note.
+            overwrite: Allow writing into an existing, non-empty directory.
+
+        Returns:
+            The vault directory :class:`~pathlib.Path`.
+        """
+        from hyperextract.utils.obsidian import export_to_obsidian
+
+        if node_label_extractor is None:
+            node_label_extractor = self._node_label_extractor
+        if edge_label_extractor is None:
+            edge_label_extractor = self._edge_label_extractor
+
+        return export_to_obsidian(
+            nodes=self.nodes,
+            edges=self.edges,
+            node_id_extractor=self.node_key_extractor,
+            incident_nodes_extractor=self.nodes_in_edge_extractor,
+            folder_path=folder_path,
+            node_label_extractor=node_label_extractor,
+            edge_label_extractor=edge_label_extractor,
+            vault_name=vault_name,
+            include_index=include_index,
+            overwrite=overwrite,
+        )

--- a/hyperextract/types/hypergraph.py
+++ b/hyperextract/types/hypergraph.py
@@ -933,3 +933,55 @@ class AutoHypergraph(
             on_search=search_callback,
             on_chat=chat_callback,
         )
+
+    # ==================== Obsidian Export ====================
+
+    def export_obsidian(
+        self,
+        folder_path: str | Path,
+        *,
+        node_label_extractor: Callable[[NodeSchema], str] = None,
+        edge_label_extractor: Callable[[EdgeSchema], str] = None,
+        vault_name: str = "Knowledge Vault",
+        include_index: bool = True,
+        overwrite: bool = False,
+    ) -> Path:
+        """Export the hypergraph as an Obsidian vault.
+
+        Writes one Markdown note per node (fields stored as YAML front-matter).
+        Each N-ary hyperedge is rendered under its first incident node, linking
+        out to the remaining members via ``[[wikilinks]]``, so the relationship
+        is browsable in Obsidian's graph view.
+
+        Args:
+            folder_path: Destination vault directory.
+            node_label_extractor: Optional node -> display title. Defaults to the
+                one from ``__init__``, then common fields, then the node id.
+            edge_label_extractor: Optional edge -> relationship label. Defaults to
+                the one from ``__init__``, then common fields, then "related to".
+            vault_name: Title used for the generated index note.
+            include_index: Whether to write an index/map-of-content note.
+            overwrite: Allow writing into an existing, non-empty directory.
+
+        Returns:
+            The vault directory :class:`~pathlib.Path`.
+        """
+        from hyperextract.utils.obsidian import export_to_obsidian
+
+        if node_label_extractor is None:
+            node_label_extractor = self._node_label_extractor
+        if edge_label_extractor is None:
+            edge_label_extractor = self._edge_label_extractor
+
+        return export_to_obsidian(
+            nodes=self.nodes,
+            edges=self.edges,
+            node_id_extractor=self.node_key_extractor,
+            incident_nodes_extractor=self.nodes_in_edge_extractor,
+            folder_path=folder_path,
+            node_label_extractor=node_label_extractor,
+            edge_label_extractor=edge_label_extractor,
+            vault_name=vault_name,
+            include_index=include_index,
+            overwrite=overwrite,
+        )

--- a/hyperextract/utils/__init__.py
+++ b/hyperextract/utils/__init__.py
@@ -2,10 +2,13 @@
 
 from .logging import get_logger, configure_logging, set_log_level
 from .client import get_client
+from .obsidian import export_to_obsidian, sanitize_filename
 
 __all__ = [
     "get_logger",
     "configure_logging",
     "set_log_level",
     "get_client",
+    "export_to_obsidian",
+    "sanitize_filename",
 ]

--- a/hyperextract/utils/obsidian.py
+++ b/hyperextract/utils/obsidian.py
@@ -1,0 +1,457 @@
+"""Obsidian vault exporter.
+
+Converts an extracted Knowledge Abstract into an `Obsidian
+<https://obsidian.md>`_ vault: a folder of Markdown notes where each node
+becomes a note and each edge becomes an internal ``[[wikilink]]``. Opening the
+resulting folder as a vault in Obsidian renders the extracted knowledge in its
+interactive graph view, fully browsable and editable.
+
+The core :func:`export_to_obsidian` function is decoupled from the AutoType
+classes (mirroring how :mod:`ontosight` powers ``AutoGraph.show``). It works on
+plain lists of Pydantic node/edge models plus a few extractor callables, so it
+supports the entire graph family (``AutoGraph`` and its temporal/spatial
+subclasses) as well as ``AutoHypergraph`` (N-ary edges).
+
+Only the Python standard library is used; no extra dependency is introduced.
+"""
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+from pydantic import BaseModel
+
+from hyperextract.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+# Characters Obsidian/most filesystems disallow (or treat specially) in note
+# file names. ``[`` / ``]`` / ``#`` / ``^`` / ``|`` break wikilink parsing.
+_ILLEGAL_FILENAME_CHARS = re.compile(r'[\\/:*?"<>|\[\]#^]')
+_WHITESPACE = re.compile(r"\s+")
+
+# Conservative "safe to emit unquoted" YAML plain-scalar charset.
+_SAFE_PLAIN = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9 _./()\-]*$")
+_NUMERIC = re.compile(r"^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$")
+_YAML_RESERVED = {"", "~", "true", "false", "yes", "no", "on", "off", "null", "none"}
+
+# Field names checked (in order) when guessing a node title / type, or an edge
+# label / description, for models with arbitrary schemas.
+_TITLE_FIELDS = ("name", "title", "label", "term", "id")
+_TYPE_FIELDS = ("type", "category", "kind", "group", "label")
+_EDGE_LABEL_FIELDS = ("relation_type", "type", "label", "name", "relation", "predicate")
+_DESCRIPTION_FIELDS = ("description", "desc", "summary", "detail", "details", "note")
+
+
+# ----------------------------------------------------------------------------
+# YAML front-matter emission (minimal, dependency-free)
+# ----------------------------------------------------------------------------
+
+
+def _needs_quote(text: str) -> bool:
+    """Return True if a string must be quoted to be a valid YAML plain scalar."""
+    if text.strip() != text:  # leading/trailing whitespace
+        return True
+    if text.lower() in _YAML_RESERVED:
+        return True
+    if _NUMERIC.match(text):
+        return True
+    return not _SAFE_PLAIN.match(text)
+
+
+def _yaml_scalar(value: Any) -> str:
+    """Serialize a scalar value to a YAML representation."""
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        return repr(value)
+    text = str(value)
+    if _needs_quote(text):
+        # A JSON-encoded string is also a valid YAML double-quoted scalar and
+        # handles all escaping (quotes, newlines, unicode) for us.
+        return json.dumps(text, ensure_ascii=False)
+    return text
+
+
+def _is_scalar(value: Any) -> bool:
+    return not isinstance(value, (dict, list, tuple))
+
+
+def _emit_kv(key: str, value: Any, indent: int) -> List[str]:
+    """Emit ``key: value`` as YAML block-style lines."""
+    pad = "  " * indent
+    key_str = _yaml_scalar(key)
+
+    if isinstance(value, dict):
+        if not value:
+            return [f"{pad}{key_str}: {{}}"]
+        lines = [f"{pad}{key_str}:"]
+        for sub_key, sub_value in value.items():
+            lines.extend(_emit_kv(str(sub_key), sub_value, indent + 1))
+        return lines
+
+    if isinstance(value, (list, tuple)):
+        if not value:
+            return [f"{pad}{key_str}: []"]
+        if all(_is_scalar(item) for item in value):
+            lines = [f"{pad}{key_str}:"]
+            item_pad = "  " * (indent + 1)
+            lines.extend(f"{item_pad}- {_yaml_scalar(item)}" for item in value)
+            return lines
+        # Mixed/nested list: fall back to a JSON flow sequence (valid YAML).
+        return [
+            f"{pad}{key_str}: {json.dumps(list(value), ensure_ascii=False, default=str)}"
+        ]
+
+    return [f"{pad}{key_str}: {_yaml_scalar(value)}"]
+
+
+def _render_frontmatter(mapping: Dict[str, Any]) -> str:
+    """Render a mapping as a YAML front-matter block (with ``---`` fences)."""
+    lines = ["---"]
+    for key, value in mapping.items():
+        lines.extend(_emit_kv(str(key), value, 0))
+    lines.append("---")
+    return "\n".join(lines)
+
+
+# ----------------------------------------------------------------------------
+# Field / filename helpers
+# ----------------------------------------------------------------------------
+
+
+def _first_field(model: BaseModel, candidates: Sequence[str]) -> Optional[str]:
+    """Return the first present, non-empty candidate field as a string."""
+    model_fields = type(model).model_fields
+    for field in candidates:
+        if field in model_fields:
+            value = getattr(model, field, None)
+            if value not in (None, "", [], {}):
+                return str(value)
+    return None
+
+
+def _safe_call(func: Optional[Callable], arg: Any) -> Optional[str]:
+    """Call ``func(arg)`` defensively, returning a string or None."""
+    if func is None:
+        return None
+    try:
+        result = func(arg)
+    except Exception as exc:  # noqa: BLE001 - extractor is user-supplied
+        logger.debug("obsidian: extractor raised %s", exc)
+        return None
+    if result in (None, ""):
+        return None
+    return str(result)
+
+
+def sanitize_filename(name: str, fallback: str = "untitled") -> str:
+    """Turn an arbitrary title into an Obsidian-safe note filename stem."""
+    cleaned = _ILLEGAL_FILENAME_CHARS.sub(" ", str(name))
+    cleaned = _WHITESPACE.sub(" ", cleaned).strip()
+    cleaned = cleaned.strip(".")  # trailing dots are problematic on Windows
+    if not cleaned:
+        return fallback
+    # Keep note names reasonable for the filesystem.
+    return cleaned[:120].strip()
+
+
+def _wikilink(stem: str, display: Optional[str] = None) -> str:
+    """Build an Obsidian wikilink targeting ``stem`` with optional display text."""
+    if display and display != stem:
+        return f"[[{stem}|{display}]]"
+    return f"[[{stem}]]"
+
+
+# ----------------------------------------------------------------------------
+# Internal node bookkeeping
+# ----------------------------------------------------------------------------
+
+
+class _NoteEntry:
+    """Resolved metadata for a single node note."""
+
+    __slots__ = ("node_id", "title", "stem", "model")
+
+    def __init__(self, node_id: str, title: str, stem: str, model: BaseModel):
+        self.node_id = node_id
+        self.title = title
+        self.stem = stem
+        self.model = model
+
+
+def _resolve_notes(
+    nodes: Sequence[BaseModel],
+    node_id_extractor: Callable[[Any], str],
+    node_label_extractor: Optional[Callable[[Any], str]],
+    reserved_stems: set,
+) -> Tuple[List[_NoteEntry], Dict[str, _NoteEntry]]:
+    """Resolve titles and unique, collision-free filename stems for all nodes."""
+    used_stems = set(reserved_stems)
+    entries: List[_NoteEntry] = []
+    by_id: Dict[str, _NoteEntry] = {}
+
+    for index, node in enumerate(nodes):
+        try:
+            node_id = str(node_id_extractor(node))
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("obsidian: node_id_extractor raised %s; skipping node", exc)
+            continue
+
+        if node_id in by_id:
+            # Defensive: ids should already be deduplicated upstream.
+            logger.debug("obsidian: duplicate node id %r; keeping first", node_id)
+            continue
+
+        title = (
+            _safe_call(node_label_extractor, node)
+            or _first_field(node, _TITLE_FIELDS)
+            or node_id
+        )
+
+        base_stem = sanitize_filename(title, fallback=f"node-{index}")
+        stem = base_stem
+        suffix = 2
+        while stem.lower() in used_stems:
+            stem = f"{base_stem} ({suffix})"
+            suffix += 1
+        used_stems.add(stem.lower())
+
+        entry = _NoteEntry(node_id=node_id, title=title, stem=stem, model=node)
+        entries.append(entry)
+        by_id[node_id] = entry
+
+    return entries, by_id
+
+
+def _incident_ids(
+    edge: Any, incident_nodes_extractor: Callable[[Any], Sequence[str]]
+) -> List[str]:
+    """Normalize an edge's incident node keys to a list of strings."""
+    try:
+        raw = incident_nodes_extractor(edge)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("obsidian: incident_nodes_extractor raised %s; skipping edge", exc)
+        return []
+    if raw is None:
+        return []
+    if isinstance(raw, (str, bytes)):
+        return [str(raw)]
+    if isinstance(raw, (list, tuple, set)):
+        return [str(item) for item in raw if item is not None]
+    return [str(raw)]
+
+
+def _build_relationships(
+    edges: Sequence[BaseModel],
+    incident_nodes_extractor: Callable[[Any], Sequence[str]],
+    edge_label_extractor: Optional[Callable[[Any], str]],
+    by_id: Dict[str, _NoteEntry],
+) -> Tuple[Dict[str, List[str]], int]:
+    """Group edges into per-source-note relationship lines.
+
+    Returns a mapping ``{source_node_id: [markdown bullet, ...]}`` and the count
+    of edges that were skipped because no incident node was known.
+    """
+    relationships: Dict[str, List[str]] = {}
+    skipped = 0
+
+    for edge in edges:
+        members = [
+            nid for nid in _incident_ids(edge, incident_nodes_extractor) if nid in by_id
+        ]
+        if not members:
+            skipped += 1
+            continue
+
+        source_id = members[0]
+        target_ids = members[1:]
+
+        label = (
+            _safe_call(edge_label_extractor, edge)
+            or _first_field(edge, _EDGE_LABEL_FIELDS)
+            or "related to"
+        )
+        description = _first_field(edge, _DESCRIPTION_FIELDS)
+
+        if target_ids:
+            targets = ", ".join(
+                _wikilink(by_id[tid].stem, by_id[tid].title) for tid in target_ids
+            )
+            line = f"- **{label}** → {targets}"
+        else:
+            # Self-contained edge (e.g. a single-member hyperedge): note it.
+            line = f"- **{label}** (self)"
+
+        if description:
+            line += f" — {description}"
+
+        relationships.setdefault(source_id, []).append(line)
+
+    return relationships, skipped
+
+
+# ----------------------------------------------------------------------------
+# Note rendering
+# ----------------------------------------------------------------------------
+
+
+def _build_frontmatter(entry: _NoteEntry) -> Dict[str, Any]:
+    """Build the YAML front-matter mapping for a node note."""
+    data: Dict[str, Any] = dict(entry.model.model_dump())
+
+    # Ensure the original id / title remain resolvable as aliases, so wikilinks
+    # written against either still point at this note.
+    extra_aliases = [
+        value for value in (entry.node_id, entry.title) if value and value != entry.stem
+    ]
+    if extra_aliases:
+        existing = data.get("aliases")
+        if isinstance(existing, list):
+            merged = list(existing)
+        elif existing:
+            merged = [existing]
+        else:
+            merged = []
+        for alias in extra_aliases:
+            if alias not in merged:
+                merged.append(alias)
+        data["aliases"] = merged
+
+    return data
+
+
+def _render_note(entry: _NoteEntry, relationship_lines: List[str]) -> str:
+    """Render a single node note's full Markdown content."""
+    parts = [_render_frontmatter(_build_frontmatter(entry)), "", f"# {entry.title}", ""]
+
+    description = _first_field(entry.model, _DESCRIPTION_FIELDS)
+    if description:
+        parts.extend([description, ""])
+
+    if relationship_lines:
+        parts.append("## Relationships")
+        parts.append("")
+        parts.extend(relationship_lines)
+        parts.append("")
+
+    return "\n".join(parts).rstrip() + "\n"
+
+
+def _render_index(entries: List[_NoteEntry], vault_name: str, edge_count: int) -> str:
+    """Render the vault index / map-of-content note."""
+    parts = [
+        _render_frontmatter({"tags": ["index"], "title": vault_name}),
+        "",
+        f"# {vault_name}",
+        "",
+        f"> {len(entries)} notes · {edge_count} relationships",
+        "",
+    ]
+
+    # Group notes by a guessed "type" field for a tidy table of contents.
+    groups: Dict[str, List[_NoteEntry]] = {}
+    for entry in entries:
+        group = _first_field(entry.model, _TYPE_FIELDS) or "Notes"
+        groups.setdefault(group, []).append(entry)
+
+    for group in sorted(groups):
+        parts.append(f"## {group}")
+        parts.append("")
+        for entry in sorted(groups[group], key=lambda e: e.title.lower()):
+            parts.append(f"- {_wikilink(entry.stem, entry.title)}")
+        parts.append("")
+
+    return "\n".join(parts).rstrip() + "\n"
+
+
+# ----------------------------------------------------------------------------
+# Public API
+# ----------------------------------------------------------------------------
+
+
+def export_to_obsidian(
+    nodes: Sequence[BaseModel],
+    edges: Sequence[BaseModel],
+    *,
+    node_id_extractor: Callable[[Any], str],
+    incident_nodes_extractor: Callable[[Any], Sequence[str]],
+    folder_path: str | Path,
+    node_label_extractor: Optional[Callable[[Any], str]] = None,
+    edge_label_extractor: Optional[Callable[[Any], str]] = None,
+    vault_name: str = "Knowledge Vault",
+    include_index: bool = True,
+    overwrite: bool = False,
+) -> Path:
+    """Export graph-structured knowledge to an Obsidian vault.
+
+    Each node is written as a Markdown note whose YAML front-matter holds the
+    node's fields; each edge is rendered under its source note as a
+    ``[[wikilink]]`` to the target note(s). For N-ary (hyper)edges the first
+    incident node is treated as the source and the rest as targets.
+
+    Args:
+        nodes: Node/entity models to export.
+        edges: Edge/relationship models to export.
+        node_id_extractor: Maps a node to its unique key (matches edge endpoints).
+        incident_nodes_extractor: Maps an edge to the node keys it connects
+            (a 2-tuple for pairwise graphs, an N-tuple for hypergraphs).
+        folder_path: Destination vault directory.
+        node_label_extractor: Optional node -> display title. Falls back to common
+            fields (name/title/...) then the node id.
+        edge_label_extractor: Optional edge -> relationship label. Falls back to
+            common fields (relation_type/type/...) then "related to".
+        vault_name: Title used for the generated index note.
+        include_index: Whether to write an index/map-of-content note.
+        overwrite: Allow writing into an existing, non-empty directory.
+
+    Returns:
+        The vault directory :class:`~pathlib.Path`.
+
+    Raises:
+        FileExistsError: If ``folder_path`` exists, is non-empty and ``overwrite``
+            is False.
+    """
+    root = Path(folder_path)
+    if root.exists() and root.is_dir() and any(root.iterdir()) and not overwrite:
+        raise FileExistsError(
+            f"Destination '{root}' already exists and is not empty. "
+            f"Pass overwrite=True to write into it."
+        )
+    root.mkdir(parents=True, exist_ok=True)
+
+    reserved_stems: set = set()
+    index_stem = None
+    if include_index:
+        index_stem = sanitize_filename(vault_name, fallback="Index")
+        reserved_stems.add(index_stem.lower())
+
+    entries, by_id = _resolve_notes(
+        nodes, node_id_extractor, node_label_extractor, reserved_stems
+    )
+    relationships, skipped_edges = _build_relationships(
+        edges, incident_nodes_extractor, edge_label_extractor, by_id
+    )
+
+    for entry in entries:
+        content = _render_note(entry, relationships.get(entry.node_id, []))
+        (root / f"{entry.stem}.md").write_text(content, encoding="utf-8")
+
+    if include_index and index_stem is not None:
+        index_content = _render_index(entries, vault_name, len(edges))
+        (root / f"{index_stem}.md").write_text(index_content, encoding="utf-8")
+
+    logger.info(
+        "obsidian: exported vault notes=%d edges=%d skipped_edges=%d path=%s",
+        len(entries),
+        len(edges),
+        skipped_edges,
+        root,
+    )
+    return root

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,7 @@ plugins:
                     - cli/commands/parse.md
                     - cli/commands/feed.md
                     - cli/commands/show.md
+                    - cli/commands/export.md
                     - cli/commands/build-index.md
                     - cli/commands/search.md
                     - cli/commands/talk.md
@@ -164,6 +165,7 @@ plugins:
                     - zh/cli/commands/parse.md
                     - zh/cli/commands/feed.md
                     - zh/cli/commands/show.md
+                    - zh/cli/commands/export.md
                     - zh/cli/commands/build-index.md
                     - zh/cli/commands/search.md
                     - zh/cli/commands/talk.md

--- a/tests/types/test_obsidian_export.py
+++ b/tests/types/test_obsidian_export.py
@@ -1,0 +1,91 @@
+"""Tests for the export_obsidian() methods on graph AutoTypes.
+
+Graphs are populated directly via the OMem stores (no LLM calls needed), so
+these run deterministically under the mock fixtures.
+"""
+
+from typing import List
+
+from pydantic import BaseModel, Field
+
+from hyperextract.types import AutoGraph, AutoHypergraph, AutoTemporalGraph
+
+
+class Entity(BaseModel):
+    name: str
+    type: str = "ENTITY"
+
+
+class Relation(BaseModel):
+    source: str
+    target: str
+    relation_type: str
+
+
+class Event(BaseModel):
+    label: str
+    participants: List[str] = Field(default_factory=list)
+
+
+def _make_graph(llm_client, embedder):
+    return AutoGraph(
+        node_schema=Entity,
+        edge_schema=Relation,
+        node_key_extractor=lambda x: x.name,
+        edge_key_extractor=lambda x: f"{x.source}-{x.relation_type}-{x.target}",
+        nodes_in_edge_extractor=lambda x: (x.source, x.target),
+        llm_client=llm_client,
+        embedder=embedder,
+    )
+
+
+class TestAutoGraphExportObsidian:
+    def test_export_creates_vault(self, tmp_path, llm_client, embedder):
+        graph = _make_graph(llm_client, embedder)
+        graph._node_memory.add(
+            [Entity(name="Apple", type="ORG"), Entity(name="Steve Jobs", type="PERSON")]
+        )
+        graph._edge_memory.add(
+            [Relation(source="Apple", target="Steve Jobs", relation_type="founded_by")]
+        )
+
+        vault = graph.export_obsidian(tmp_path / "vault", vault_name="MyKB")
+
+        assert vault == tmp_path / "vault"
+        assert (vault / "Apple.md").exists()
+        assert (vault / "Steve Jobs.md").exists()
+        assert (vault / "MyKB.md").exists()
+        assert "[[Steve Jobs]]" in (vault / "Apple.md").read_text(encoding="utf-8")
+
+    def test_empty_graph_exports_index_only(self, tmp_path, llm_client, embedder):
+        graph = _make_graph(llm_client, embedder)
+        vault = graph.export_obsidian(tmp_path / "vault", vault_name="Empty")
+        assert (vault / "Empty.md").exists()
+        assert len(list(vault.glob("*.md"))) == 1
+
+    def test_temporal_graph_inherits_method(self, llm_client, embedder):
+        # AutoTemporalGraph subclasses AutoGraph, so it inherits export_obsidian.
+        assert hasattr(AutoTemporalGraph, "export_obsidian")
+
+
+class TestAutoHypergraphExportObsidian:
+    def test_export_nary_edge(self, tmp_path, llm_client, embedder):
+        hg = AutoHypergraph(
+            node_schema=Entity,
+            edge_schema=Event,
+            node_key_extractor=lambda x: x.name,
+            edge_key_extractor=lambda x: f"{x.label}_{sorted(x.participants)}",
+            nodes_in_edge_extractor=lambda x: tuple(x.participants),
+            edge_label_extractor=lambda x: x.label,
+            llm_client=llm_client,
+            embedder=embedder,
+        )
+        hg._node_memory.add([Entity(name="A"), Entity(name="B"), Entity(name="C")])
+        hg._edge_memory.add([Event(label="meeting", participants=["A", "B", "C"])])
+
+        vault = hg.export_obsidian(tmp_path / "vault")
+
+        source = (vault / "A.md").read_text(encoding="utf-8")
+        assert "meeting" in source
+        assert "[[B]]" in source
+        assert "[[C]]" in source

--- a/tests/utils/test_obsidian.py
+++ b/tests/utils/test_obsidian.py
@@ -1,0 +1,305 @@
+"""Unit tests for the Obsidian vault exporter (hyperextract.utils.obsidian).
+
+These tests exercise the exporter directly with plain Pydantic models and
+lambda extractors — no LLM/embedder is involved, so they are fast and fully
+deterministic.
+"""
+
+from typing import List, Optional
+
+import pytest
+from pydantic import BaseModel, Field
+
+from hyperextract.utils.obsidian import (
+    export_to_obsidian,
+    sanitize_filename,
+    _render_frontmatter,
+)
+
+
+# ---------------------------------------------------------------------------
+# Schemas + helpers
+# ---------------------------------------------------------------------------
+
+
+class Entity(BaseModel):
+    name: str
+    type: str = "ENTITY"
+    description: Optional[str] = None
+    properties: dict = Field(default_factory=dict)
+
+
+class Relation(BaseModel):
+    source: str
+    target: str
+    relation_type: str
+    description: Optional[str] = None
+
+
+class Event(BaseModel):
+    """N-ary hyperedge schema."""
+
+    label: str
+    participants: List[str]
+
+
+def export_graph(folder, nodes, edges, **kwargs):
+    return export_to_obsidian(
+        nodes,
+        edges,
+        node_id_extractor=lambda n: n.name,
+        incident_nodes_extractor=lambda e: (e.source, e.target),
+        folder_path=folder,
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# sanitize_filename
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeFilename:
+    def test_keeps_plain_names(self):
+        assert sanitize_filename("Steve Jobs") == "Steve Jobs"
+
+    def test_replaces_illegal_chars(self):
+        result = sanitize_filename('A/B:C*?"<>|[]#^')
+        for bad in '\\/:*?"<>|[]#^':
+            assert bad not in result
+
+    def test_collapses_whitespace(self):
+        assert sanitize_filename("a   b\tc") == "a b c"
+
+    def test_empty_uses_fallback(self):
+        assert sanitize_filename("///", fallback="x") == "x"
+        assert sanitize_filename("", fallback="x") == "x"
+
+    def test_strips_trailing_dots(self):
+        assert sanitize_filename("name...") == "name"
+
+    def test_truncates_long_names(self):
+        assert len(sanitize_filename("z" * 500)) <= 120
+
+
+# ---------------------------------------------------------------------------
+# Front-matter rendering
+# ---------------------------------------------------------------------------
+
+
+class TestFrontmatter:
+    def test_has_fences(self):
+        out = _render_frontmatter({"name": "Apple"})
+        assert out.startswith("---\n")
+        assert out.endswith("\n---")
+
+    def test_yaml_roundtrip_preserves_structure(self):
+        yaml = pytest.importorskip("yaml")
+        data = {
+            "name": "Apple: the fruit",  # colon -> must be quoted
+            "count": 3,
+            "ratio": 1.5,
+            "active": True,
+            "missing": None,
+            "tags": ["a", "b c", "needs: quote"],
+            "nested": {"founded": 1976, "ceo": "Tim Cook"},
+            "mixed": [{"k": 1}, "v"],
+            "unicode": "苹果",
+        }
+        rendered = _render_frontmatter(data)
+        body = rendered.strip().strip("-").strip()
+        loaded = yaml.safe_load(body)
+        assert loaded == data
+
+    def test_reserved_words_quoted(self):
+        yaml = pytest.importorskip("yaml")
+        data = {"a": "yes", "b": "null", "c": "true"}
+        loaded = yaml.safe_load(_render_frontmatter(data).strip().strip("-").strip())
+        # Without quoting these would parse as bool/None instead of strings.
+        assert loaded == data
+
+
+# ---------------------------------------------------------------------------
+# export_to_obsidian — structure
+# ---------------------------------------------------------------------------
+
+
+class TestExportStructure:
+    def test_creates_note_per_node_plus_index(self, tmp_path):
+        nodes = [
+            Entity(name="Apple", type="ORG"),
+            Entity(name="Steve Jobs", type="PERSON"),
+        ]
+        edges = [
+            Relation(source="Apple", target="Steve Jobs", relation_type="founded_by")
+        ]
+
+        export_graph(tmp_path / "vault", nodes, edges, vault_name="TestVault")
+
+        vault = tmp_path / "vault"
+        assert (vault / "Apple.md").exists()
+        assert (vault / "Steve Jobs.md").exists()
+        assert (vault / "TestVault.md").exists()  # index
+        assert len(list(vault.glob("*.md"))) == 3
+
+    def test_note_has_frontmatter_and_heading(self, tmp_path):
+        export_graph(tmp_path / "v", [Entity(name="Apple", type="ORG")], [])
+        content = (tmp_path / "v" / "Apple.md").read_text(encoding="utf-8")
+        assert content.startswith("---\n")
+        assert "name: Apple" in content
+        assert "type: ORG" in content
+        assert "# Apple" in content
+
+    def test_description_rendered_in_body(self, tmp_path):
+        node = Entity(name="Apple", description="A tech company.")
+        export_graph(tmp_path / "v", [node], [])
+        content = (tmp_path / "v" / "Apple.md").read_text(encoding="utf-8")
+        assert "A tech company." in content
+
+    def test_no_index_when_disabled(self, tmp_path):
+        export_graph(
+            tmp_path / "v",
+            [Entity(name="Apple")],
+            [],
+            vault_name="TestVault",
+            include_index=False,
+        )
+        assert not (tmp_path / "v" / "TestVault.md").exists()
+        assert (tmp_path / "v" / "Apple.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# export_to_obsidian — edges / wikilinks
+# ---------------------------------------------------------------------------
+
+
+class TestExportEdges:
+    def test_edge_renders_wikilink_under_source(self, tmp_path):
+        nodes = [Entity(name="Apple"), Entity(name="Steve Jobs")]
+        edges = [
+            Relation(
+                source="Apple",
+                target="Steve Jobs",
+                relation_type="founded_by",
+                description="in 1976",
+            )
+        ]
+        export_graph(tmp_path / "v", nodes, edges)
+
+        source = (tmp_path / "v" / "Apple.md").read_text(encoding="utf-8")
+        assert "## Relationships" in source
+        assert "[[Steve Jobs]]" in source
+        assert "founded_by" in source
+        assert "in 1976" in source
+
+    def test_unknown_endpoints_are_skipped(self, tmp_path):
+        nodes = [Entity(name="Apple")]
+        edges = [Relation(source="Apple", target="Ghost", relation_type="x")]
+        # Should not raise; Apple note has no resolvable relationship target.
+        export_graph(tmp_path / "v", nodes, edges)
+        source = (tmp_path / "v" / "Apple.md").read_text(encoding="utf-8")
+        assert "[[Ghost]]" not in source
+
+    def test_custom_edge_label_extractor(self, tmp_path):
+        nodes = [Entity(name="A"), Entity(name="B")]
+        edges = [Relation(source="A", target="B", relation_type="r")]
+        export_to_obsidian(
+            nodes,
+            edges,
+            node_id_extractor=lambda n: n.name,
+            incident_nodes_extractor=lambda e: (e.source, e.target),
+            folder_path=tmp_path / "v",
+            edge_label_extractor=lambda e: "LINKS-TO",
+        )
+        assert "LINKS-TO" in (tmp_path / "v" / "A.md").read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# export_to_obsidian — naming / aliases / collisions
+# ---------------------------------------------------------------------------
+
+
+class TestExportNaming:
+    def test_illegal_chars_in_node_name(self, tmp_path):
+        nodes = [Entity(name="A/B:C")]
+        export_graph(tmp_path / "v", nodes, [])
+        files = list((tmp_path / "v").glob("*.md"))
+        node_files = [f for f in files if f.stem != "Knowledge Vault"]
+        assert len(node_files) == 1
+        for bad in '\\/:*?"<>|':
+            assert bad not in node_files[0].name
+
+    def test_label_extractor_adds_alias_for_id(self, tmp_path):
+        nodes = [Entity(name="apple_inc")]
+        export_to_obsidian(
+            nodes,
+            [],
+            node_id_extractor=lambda n: n.name,
+            incident_nodes_extractor=lambda e: (e.source, e.target),
+            folder_path=tmp_path / "v",
+            node_label_extractor=lambda n: "Apple Inc",
+        )
+        content = (tmp_path / "v" / "Apple Inc.md").read_text(encoding="utf-8")
+        assert "aliases:" in content
+        assert "apple_inc" in content
+
+    def test_colliding_titles_get_unique_files(self, tmp_path):
+        # Two distinct ids whose titles sanitize to the same stem.
+        nodes = [Entity(name="A:B"), Entity(name="A/B")]
+        export_graph(tmp_path / "v", nodes, [], include_index=False)
+        node_files = sorted(f.name for f in (tmp_path / "v").glob("*.md"))
+        assert len(node_files) == 2
+        assert node_files[0] != node_files[1]
+
+    def test_wikilink_uses_sanitized_stem(self, tmp_path):
+        nodes = [Entity(name="Apple"), Entity(name="Steve/Jobs")]
+        edges = [Relation(source="Apple", target="Steve/Jobs", relation_type="x")]
+        export_graph(tmp_path / "v", nodes, edges)
+        source = (tmp_path / "v" / "Apple.md").read_text(encoding="utf-8")
+        # Link target is the sanitized stem; display keeps original via alias pipe.
+        assert "[[Steve Jobs|Steve/Jobs]]" in source
+
+
+# ---------------------------------------------------------------------------
+# export_to_obsidian — overwrite guard
+# ---------------------------------------------------------------------------
+
+
+class TestOverwriteGuard:
+    def test_raises_on_nonempty_dir(self, tmp_path):
+        dest = tmp_path / "v"
+        dest.mkdir()
+        (dest / "existing.md").write_text("keep me", encoding="utf-8")
+        with pytest.raises(FileExistsError):
+            export_graph(dest, [Entity(name="Apple")], [])
+
+    def test_overwrite_allows_nonempty_dir(self, tmp_path):
+        dest = tmp_path / "v"
+        dest.mkdir()
+        (dest / "existing.md").write_text("keep me", encoding="utf-8")
+        export_graph(dest, [Entity(name="Apple")], [], overwrite=True)
+        assert (dest / "Apple.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# export_to_obsidian — hypergraph (N-ary edges)
+# ---------------------------------------------------------------------------
+
+
+class TestHypergraphExport:
+    def test_nary_edge_links_all_members(self, tmp_path):
+        nodes = [Entity(name="A"), Entity(name="B"), Entity(name="C")]
+        edges = [Event(label="meeting", participants=["A", "B", "C"])]
+        export_to_obsidian(
+            nodes,
+            edges,
+            node_id_extractor=lambda n: n.name,
+            incident_nodes_extractor=lambda e: tuple(e.participants),
+            edge_label_extractor=lambda e: e.label,
+            folder_path=tmp_path / "v",
+        )
+        # First member is the source; remaining are linked targets.
+        source = (tmp_path / "v" / "A.md").read_text(encoding="utf-8")
+        assert "meeting" in source
+        assert "[[B]]" in source
+        assert "[[C]]" in source


### PR DESCRIPTION
## Summary

Adds an **Obsidian vault exporter**: turn any extracted Knowledge Abstract into a folder of Markdown notes that Obsidian renders in its interactive graph view.

- Each **node** → a Markdown note, with the node's fields stored as YAML front-matter and a `# Title` heading.
- Each **edge** → an internal `[[wikilink]]` rendered under its source note's `## Relationships` section (with the relationship label and description when available).
- An **index / map-of-content** note grouping nodes by type.

Knowledge graphs map naturally onto Obsidian vaults (`[[wikilinks]]` are exactly its native model), so this lets users browse and edit extracted knowledge directly in Obsidian. The import direction is already covered — `he parse <dir>` globs `*.md`, and a vault is just a folder of Markdown — so only export was missing.

## What's included

- `hyperextract/utils/obsidian.py` — a dependency-free, generic `export_to_obsidian(...)` (decoupled from the AutoTypes, mirroring how `ontosight` powers `show`). Handles filename sanitization, a minimal YAML front-matter emitter (conservative quoting; JSON-as-YAML fallback for nested values), wikilink resolution with aliases, stem-collision handling, and the index note.
- `AutoGraph.export_obsidian(...)` — also inherited by `AutoTemporalGraph` / `AutoSpatialGraph` / `AutoSpatioTemporalGraph`.
- `AutoHypergraph.export_obsidian(...)` — N-ary edges (first incident node is the source, the rest are linked targets).
- `he export <ka_path> -o <vault>` CLI command (`--name`, `--no-index`, `--force`).
- Tests: `tests/utils/test_obsidian.py` (exporter internals + YAML round-trip) and `tests/types/test_obsidian_export.py` (the AutoType methods under mocks).
- README / README_ZH usage docs.

## Usage

```bash
he parse examples/en/tesla.md -t general/biography_graph -o ./output/ -l en
he export ./output/ -o ./vault/    # open ./vault/ as a vault in Obsidian
```

```python
ka.export_obsidian("./vault/", vault_name="Tesla KB")
```

## Notes

- No new runtime dependency (standard library only).
- Purely additive — no changes to extraction or serialization paths.
- Pre-existing unrelated test `tests/types/test_extraction_logging.py::...test_extract_data_emits_debug_logs` fails on `main` too (structlog vs the test's stdlib logging handler); not touched here.

## Test plan

- `ruff format --check hyperextract` and `ruff check hyperextract` pass.
- `pytest tests/utils/test_obsidian.py tests/types/test_obsidian_export.py` → 27 passed (mock mode, no API key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)