### PR TITLE
fix(template): resolve multi-word llm_* merge strategies (were silently None)

### DIFF
--- a/hyperextract/utils/template_engine/parsers/options.py
+++ b/hyperextract/utils/template_engine/parsers/options.py
@@ -14,12 +14,12 @@ from .schemas import (
 
 def resolve_merge_strategy(strategy_name: VALID_MERGE_STRATEGIES) -> MergeStrategy:
     """Resolve merge strategy from string to MergeStrategy enum."""
-    if "llm" in strategy_name:
-        parts = strategy_name.split("_")
-        if len(parts) == 2 and parts[0] in ["llm"]:
-            return getattr(getattr(MergeStrategy, parts[0].upper()), parts[1].upper())
-    else:
-        return MergeStrategy[strategy_name.upper()]
+    if strategy_name.startswith("llm_"):
+        # Map every "llm_*" variant onto the nested MergeStrategy.LLM member,
+        # e.g. "llm_balanced" -> MergeStrategy.LLM.BALANCED,
+        #      "llm_prefer_incoming" -> MergeStrategy.LLM.PREFER_INCOMING.
+        return getattr(MergeStrategy.LLM, strategy_name[len("llm_") :].upper())
+    return MergeStrategy[strategy_name.upper()]
 
 
 class Options(BaseModel):

--- a/tests/template_engine/test_parser_options.py
+++ b/tests/template_engine/test_parser_options.py
@@ -1,0 +1,33 @@
+"""Unit tests for template parsers - options (merge strategy resolution)."""
+
+from typing import get_args
+
+import pytest
+
+from hyperextract.utils.template_engine.parsers.options import resolve_merge_strategy
+from hyperextract.utils.template_engine.parsers.schemas.base import (
+    VALID_MERGE_STRATEGIES,
+)
+
+
+class TestResolveMergeStrategy:
+    """``resolve_merge_strategy`` must resolve every documented strategy."""
+
+    @pytest.mark.parametrize("strategy", get_args(VALID_MERGE_STRATEGIES))
+    def test_every_valid_strategy_resolves(self, strategy):
+        """No value declared in ``VALID_MERGE_STRATEGIES`` may resolve to None.
+
+        Regression test: multi-word ``llm_*`` strategies such as
+        ``llm_prefer_incoming`` / ``llm_prefer_existing`` used to fall through the
+        resolver and silently return ``None`` (their name splits into 3 parts,
+        which failed the ``len(parts) == 2`` guard).
+        """
+        assert resolve_merge_strategy(strategy) is not None
+
+    @pytest.mark.parametrize("strategy", ["llm_prefer_incoming", "llm_prefer_existing"])
+    def test_multiword_llm_strategies_map_to_llm_member(self, strategy):
+        """Multi-word ``llm_*`` strategies map onto the nested ``MergeStrategy.LLM``."""
+        from ontomem.merger import MergeStrategy
+
+        expected = getattr(MergeStrategy.LLM, strategy[len("llm_") :].upper())
+        assert resolve_merge_strategy(strategy) == expected


### PR DESCRIPTION
## Summary

`resolve_merge_strategy()` silently returns `None` for two of the six documented
merge strategies — `llm_prefer_incoming` and `llm_prefer_existing`. Both are declared
in the public `VALID_MERGE_STRATEGIES` literal, so a template that sets
`options.merge_strategy: llm_prefer_incoming` ends up passing `None` into the merger
instead of the intended strategy.

## Root cause

```python
if "llm" in strategy_name:
    parts = strategy_name.split("_")
    if len(parts) == 2 and parts[0] in ["llm"]:   # only matches 2-part names
        return getattr(getattr(MergeStrategy, parts[0].upper()), parts[1].upper())
else:
    return MergeStrategy[strategy_name.upper()]
# multi-word "llm_*" names fall through -> implicit `return None`
```

`"llm_prefer_incoming".split("_")` -> `["llm", "prefer", "incoming"]` (3 parts), which
fails the `len(parts) == 2` guard. There is no fallback, so the function returns `None`.

| strategy | before | after |
|---|---|---|
| `merge_field` / `keep_incoming` / `keep_existing` | ✅ | ✅ (unchanged) |
| `llm_balanced` | ✅ | ✅ (unchanged) |
| `llm_prefer_incoming` | ❌ `None` | ✅ `MergeStrategy.LLM.PREFER_INCOMING` |
| `llm_prefer_existing` | ❌ `None` | ✅ `MergeStrategy.LLM.PREFER_EXISTING` |

## Fix

Match any `llm_*` strategy and map its suffix onto the nested `MergeStrategy.LLM`
member, rather than hard-coding a 2-part split. This also naturally covers
`llm_custom_rule`.

## Tests

Adds `tests/template_engine/test_parser_options.py`, which parametrizes over every
value in `VALID_MERGE_STRATEGIES` and asserts none resolve to `None`, plus checks that
the two multi-word strategies map to the correct `MergeStrategy.LLM` members.
Verified against `ontomem==0.2.3`.
