### PR TITLE
fix: avoid sending empty-string input to embedding providers

### DIFF
--- a/hyperextract/utils/client.py
+++ b/hyperextract/utils/client.py
@@ -172,11 +172,19 @@ class CompatibleEmbeddings(Embeddings):
         counts: Dict[int, int] = {}
 
         def _embed_batch(b: List[Tuple[str, int]]) -> None:
+            # Skip blank chunks: many OpenAI-compatible providers (e.g. Bailian /
+            # DashScope) reject empty-string input with a 400. Blank texts are
+            # backfilled with a zero vector after all batches complete.
+            non_blank = [(text, idx) for text, idx in b if text.strip()]
+            if not non_blank:
+                return
             response = self._client.embeddings.create(
-                input=[text for text, _ in b],
+                input=[text for text, _ in non_blank],
                 model=self._model,
             )
-            for (text, orig_idx), emb_data in zip(b, response.data, strict=False):
+            for (text, orig_idx), emb_data in zip(
+                non_blank, response.data, strict=False
+            ):
                 emb = emb_data.embedding
                 if orig_idx not in sums:
                     sums[orig_idx] = list(emb)
@@ -196,20 +204,30 @@ class CompatibleEmbeddings(Embeddings):
             _embed_batch(batch)
 
         # Divide each running sum by its chunk count to get the mean embedding.
+        dim: Optional[int] = None
         for orig_idx, running in sums.items():
             count = counts[orig_idx]
-            all_embeddings[orig_idx] = [v / count for v in running]
+            mean = [v / count for v in running]
+            all_embeddings[orig_idx] = mean
+            dim = len(mean)
 
-        # Fill in any missing embeddings with empty-string embedding
+        # Backfill blank texts (which were skipped above) with a zero vector so
+        # the output stays aligned with the input. We never send an empty string
+        # to the API. If every input was blank we have no reference dimension, so
+        # probe once with a non-empty placeholder to learn it.
         missing_indices = [i for i, e in enumerate(all_embeddings) if e is None]
         if missing_indices:
-            response = self._client.embeddings.create(
-                input="",
-                model=self._model,
-            )
-            default_emb = response.data[0].embedding
+            if dim is None:
+                # Non-whitespace placeholder: a single space can be stripped to
+                # empty by strict providers and rejected like an empty string.
+                response = self._client.embeddings.create(
+                    input=".",
+                    model=self._model,
+                )
+                dim = len(response.data[0].embedding)
+            zero_vector = [0.0] * dim
             for i in missing_indices:
-                all_embeddings[i] = default_emb
+                all_embeddings[i] = list(zero_vector)
 
         return all_embeddings  # type: ignore[return-value]
 

--- a/tests/utils/test_client.py
+++ b/tests/utils/test_client.py
@@ -347,6 +347,57 @@ class TestCompatibleEmbeddings:
 
         assert result == [[0.1, 0.2, 0.3]]
 
+    def test_blank_text_not_sent_and_zero_filled(self, mock_openai_client):
+        """Blank texts are never sent to the API and backfill as a zero vector.
+
+        Providers like Bailian/DashScope reject empty-string input, so a blank
+        document must not appear in the request and must still keep the output
+        aligned with the input.
+        """
+        emb = CompatibleEmbeddings(
+            model="test-model",
+            api_key="sk-test",
+            base_url="http://test/v1",
+        )
+        mock_openai_client.embeddings.create.return_value = MagicMock(
+            data=[
+                MagicMock(embedding=[0.1, 0.2, 0.3]),
+                MagicMock(embedding=[0.4, 0.5, 0.6]),
+            ]
+        )
+        with patch.object(emb, "_client", mock_openai_client):
+            result = emb.embed_documents(["hello", "", "world"])
+
+        # Output aligns with input; blank index is a zero vector.
+        assert len(result) == 3
+        assert result[0] == [0.1, 0.2, 0.3]
+        assert result[1] == [0.0, 0.0, 0.0]
+        assert result[2] == [0.4, 0.5, 0.6]
+
+        # The blank string was never included in any API request.
+        assert mock_openai_client.embeddings.create.call_count == 1
+        sent = mock_openai_client.embeddings.create.call_args.kwargs["input"]
+        assert sent == ["hello", "world"]
+
+    def test_all_blank_probes_with_non_empty_input(self, mock_openai_client):
+        """When every input is blank, the dimension probe uses non-empty input."""
+        emb = CompatibleEmbeddings(
+            model="test-model",
+            api_key="sk-test",
+            base_url="http://test/v1",
+        )
+        mock_openai_client.embeddings.create.return_value = MagicMock(
+            data=[MagicMock(embedding=[0.0, 0.0])]
+        )
+        with patch.object(emb, "_client", mock_openai_client):
+            result = emb.embed_documents(["", "   "])
+
+        assert result == [[0.0, 0.0], [0.0, 0.0]]
+        # Exactly one (probe) call, and its input is non-empty.
+        assert mock_openai_client.embeddings.create.call_count == 1
+        probe_input = mock_openai_client.embeddings.create.call_args.kwargs["input"]
+        assert isinstance(probe_input, str) and probe_input.strip()
+
 
 # =============================================================================
 # get_client (config file)


### PR DESCRIPTION
## Problem
`CompatibleEmbeddings.embed_documents` could send empty-string input to the embeddings API in two places: blank documents were passed straight through in a batch, and the "missing embeddings" fallback called `embeddings.create(input="")`. OpenAI-compatible providers such as Bailian/DashScope reject empty input with a 400, crashing indexing — the same error family as #33.

## Fix
- Filter blank chunks before each request so empty strings are never sent.
- Backfill blank texts with a zero vector (dimension inferred from real embeddings) to keep the output aligned with the input.
- If every input is blank, probe once with a non-whitespace placeholder to learn the embedding dimension (a single space can be stripped to empty and rejected).

## Tests
- Blank text among real texts is never sent and backfills as a zero vector.
- All-blank input probes with non-empty input and returns zero vectors.
- `tests/utils/test_client.py`: 37 passed.
