### PR TITLE
test: make metadata-updated-on-feed assertion deterministic

### DIFF
--- a/tests/types/test_model_basic.py
+++ b/tests/types/test_model_basic.py
@@ -1,5 +1,7 @@
 """Unit tests for AutoModel basic functionality."""
 
+from datetime import datetime, timedelta
+
 import pytest
 from pydantic import BaseModel, Field
 from typing import Optional
@@ -107,11 +109,16 @@ class TestAutoModelBasic:
             embedder=embedder,
         )
 
-        original_updated_at = model.metadata["updated_at"]
+        # Seed a known-past timestamp so the assertion does not depend on the
+        # resolution of datetime.now(): with mocked clients feed_text can finish
+        # within the same clock tick as construction, making the new timestamp
+        # equal (not greater) and the test intermittently fail.
+        past = datetime.now() - timedelta(seconds=1)
+        model.metadata["updated_at"] = past
 
         model.feed_text(SHORT_TEXT)
 
-        assert model.metadata["updated_at"] > original_updated_at
+        assert model.metadata["updated_at"] > past
 
     def test_create_empty_instance(self, llm_client, embedder):
         """Test that _create_empty_instance creates a properly configured instance."""


### PR DESCRIPTION
## Problem
`test_metadata_updated_on_feed` asserts that `metadata["updated_at"]` is strictly greater after `feed_text`. Both timestamps come from `datetime.now()`, and with mocked clients `feed_text` can finish within the same clock tick as construction (notably on Windows, where `datetime.now()` resolution is ~15 ms). The two timestamps then compare equal and the test fails intermittently.

## Fix
Seed `updated_at` to a known past timestamp (`datetime.now() - timedelta(seconds=1)`) before calling `feed_text`, then assert the refreshed timestamp is greater than that seed. This keeps the test's intent — `feed_text` updates `updated_at` — while removing the dependency on sub-tick clock resolution.

Production code is unchanged; the flakiness was in the test's timing assumption.

## Verification
- The test passed 20/20 consecutive runs (previously intermittent).
- `tests/types/test_model_basic.py`: 9 passed.
