### PR TITLE
fix: correct AutoSet.update batch-add and copy timestamps

### DIFF
--- a/hyperextract/types/set.py
+++ b/hyperextract/types/set.py
@@ -530,7 +530,11 @@ class AutoSet(BaseAutoType[AutoSetSchema[ItemSchema]], Generic[ItemSchema]):
         Args:
             items: List of items to add.
         """
-        self.add(items)
+        # add() takes a single item and would wrap the whole list as one entry;
+        # pass the list straight to the backing store so each item is added.
+        self._data_memory.add(items)
+        self.clear_index()
+        self.metadata["updated_at"] = datetime.now()
 
     def discard(self, key: Any) -> None:
         """Removes an item by its unique key value, silently ignoring if not found.
@@ -601,7 +605,9 @@ class AutoSet(BaseAutoType[AutoSetSchema[ItemSchema]], Generic[ItemSchema]):
         items_copy = [item.model_copy(deep=True) for item in self._data_memory.items]
         new_set._data_memory.add(items_copy)
         new_set.metadata = self.metadata.copy()
-        new_set.metadata["created_at"] = datetime.now()
+        # A copy preserves the original creation time and refreshes the
+        # modification time (matching AutoList.copy()).
+        new_set.metadata["updated_at"] = datetime.now()
 
         return new_set
 

--- a/tests/types/test_set_dedup.py
+++ b/tests/types/test_set_dedup.py
@@ -1,5 +1,7 @@
 """Unit tests for AutoSet deduplication functionality."""
 
+from datetime import datetime, timedelta
+
 import pytest
 from pydantic import BaseModel, Field
 from typing import Optional
@@ -293,3 +295,45 @@ class TestAutoSetDedup:
         assert len(copied) == 1
         assert "Python" in copied
         assert copied is not auto_set
+
+    def test_update_adds_all_items(self, llm_client, embedder):
+        """update() adds every item in the list, not the whole list as one entry."""
+        auto_set = AutoSet(
+            item_schema=KeywordItemSchema,
+            llm_client=llm_client,
+            embedder=embedder,
+            key_extractor=lambda x: x.term,
+        )
+
+        auto_set.update(
+            [
+                KeywordItemSchema(term="Python"),
+                KeywordItemSchema(term="Java"),
+                KeywordItemSchema(term="Rust"),
+            ]
+        )
+
+        assert len(auto_set) == 3
+        assert "Python" in auto_set
+        assert "Java" in auto_set
+        assert "Rust" in auto_set
+
+    def test_copy_preserves_created_at(self, llm_client, embedder):
+        """copy() keeps the original created_at and refreshes updated_at."""
+        auto_set = AutoSet(
+            item_schema=KeywordItemSchema,
+            llm_client=llm_client,
+            embedder=embedder,
+            key_extractor=lambda x: x.term,
+        )
+        auto_set.add(KeywordItemSchema(term="Python"))
+
+        # Seed a known-past created_at so we can assert the copy preserves it
+        # rather than resetting it to "now".
+        past = datetime.now() - timedelta(days=1)
+        auto_set.metadata["created_at"] = past
+
+        copied = auto_set.copy()
+
+        assert copied.metadata["created_at"] == past
+        assert copied.metadata["updated_at"] > past


### PR DESCRIPTION
## Problem
Two correctness bugs in `AutoSet`:

1. **`update()` does not batch-add.** `update(items)` calls `self.add(items)`, but `add()` expects a single item and wraps its argument as `[item]`. Passing a list therefore stores the entire list as one malformed entry instead of adding each item. Batch update is effectively broken.

2. **`copy()` resets `created_at`.** `copy()` sets `created_at = datetime.now()`, discarding the original creation time and leaving `updated_at` stale. A copy should preserve `created_at` and refresh `updated_at` — which is exactly what `AutoList.copy()` does.

## Fix
- `update()` now adds the list straight to the backing store, clears the index, and updates `updated_at`.
- `copy()` now preserves `created_at` and refreshes `updated_at`, consistent with `AutoList.copy()`.

## Tests
Added two tests (both verified to fail on the pre-fix code and pass after):
- `test_update_adds_all_items` — `update([a, b, c])` yields three items.
- `test_copy_preserves_created_at` — copy keeps the original `created_at` and refreshes `updated_at`.

Set test suite: 58 passed. `ruff check`/`ruff format --check` on `hyperextract` clean.
