### PR TITLE
fix: merge metadata consistently in AutoList list+list addition

### DIFF
--- a/hyperextract/types/list.py
+++ b/hyperextract/types/list.py
@@ -476,8 +476,12 @@ class AutoList(BaseAutoType[AutoListSchema[ItemSchema]], Generic[ItemSchema]):
             # Create new instance with merged items
             new_instance = self._create_empty_instance()
             new_instance._data.items = self.items + other.items
-            new_instance.metadata["created_at"] = self.metadata.get("created_at")
-            new_instance.metadata["updated_at"] = self.metadata.get("updated_at")
+            # Keep the earliest creation time and mark the merge as just updated,
+            # consistent with the List + AutoModel case below and BaseAutoType.
+            new_instance.metadata["created_at"] = min(
+                self.metadata["created_at"], other.metadata["created_at"]
+            )
+            new_instance.metadata["updated_at"] = datetime.now()
             return new_instance
 
         # Case 2: AutoList + AutoModel → AutoList (append model)

--- a/tests/types/test_list_iteration.py
+++ b/tests/types/test_list_iteration.py
@@ -1,5 +1,7 @@
 """Unit tests for AutoList iteration and membership."""
 
+from datetime import datetime, timedelta
+
 import pytest
 from pydantic import BaseModel, Field
 from typing import Optional
@@ -190,6 +192,37 @@ class TestAutoListOperators:
         result = list1 + list2 + list3
 
         assert len(result) == 3
+
+    def test_add_merges_metadata(self, llm_client, embedder):
+        """List + List keeps the earliest created_at and a fresh updated_at."""
+        list1 = AutoList(
+            item_schema=PersonItemSchema,
+            llm_client=llm_client,
+            embedder=embedder,
+        )
+        list2 = AutoList(
+            item_schema=PersonItemSchema,
+            llm_client=llm_client,
+            embedder=embedder,
+        )
+        list1.append(PersonItemSchema(name="John"))
+        list2.append(PersonItemSchema(name="Jane"))
+
+        # list2 is the older list; both carry a stale updated_at. The left
+        # operand (list1) is the newer one, so a fix that merely copies self's
+        # timestamps would pick the wrong created_at and a stale updated_at.
+        older = datetime.now() - timedelta(days=2)
+        newer = datetime.now() - timedelta(days=1)
+        list1.metadata["created_at"] = newer
+        list2.metadata["created_at"] = older
+        list1.metadata["updated_at"] = older
+        list2.metadata["updated_at"] = older
+
+        before = datetime.now()
+        result = list1 + list2
+
+        assert result.metadata["created_at"] == older
+        assert result.metadata["updated_at"] >= before
 
     def test_add_with_different_schema_raises(self, llm_client, embedder):
         """Test that adding lists with different schemas raises TypeError."""


### PR DESCRIPTION
## Problem
`AutoList.__add__` handles metadata inconsistently between its two branches.

For **List + List** ([list.py](hyperextract/types/list.py)) it copies only the left operand's timestamps:

```python
new_instance.metadata["created_at"] = self.metadata.get("created_at")
new_instance.metadata["updated_at"] = self.metadata.get("updated_at")
```

This ignores the right operand's `created_at` and carries over a stale `updated_at`. Everywhere else in the codebase — the **List + AutoModel** branch immediately below, and `BaseAutoType`'s merge — uses the earliest `created_at` and a fresh `updated_at`:

```python
new_list.metadata["created_at"] = min(self.metadata["created_at"], other.metadata["created_at"])
new_list.metadata["updated_at"] = datetime.now()
```

## Fix
Make List + List follow the same convention: `created_at = min(self, other)` and `updated_at = datetime.now()`.

## Tests
Added `test_add_merges_metadata` (verified to fail on the pre-fix code and pass after): when the left operand is the newer list, the combined list still takes the earlier `created_at` and refreshes `updated_at`.

`tests/types/test_list_iteration.py`: 15 passed. `ruff check`/`ruff format --check` on `hyperextract` clean.
