### PR TITLE
fix: guard empty first chunk in AutoGraph/AutoHypergraph batch merge

### DIFF
--- a/hyperextract/types/graph.py
+++ b/hyperextract/types/graph.py
@@ -714,11 +714,14 @@ class AutoGraph(
                 logger.warning("stage=merge_batch_empty_tuple nodes_and_edges_empty")
                 return self.graph_schema(nodes=[], edges=[])
 
-            if nodes_lists:
+            # Guard against an empty first chunk: nodes_lists[0] (or edges_lists[0])
+            # can be an empty list when a chunk produced no nodes/edges, so
+            # indexing [0][0] without the inner check raises IndexError.
+            if nodes_lists and nodes_lists[0]:
                 assert isinstance(nodes_lists[0][0], self.node_schema), (
                     "Invalid node list format for batch merging"
                 )
-            if edges_lists:
+            if edges_lists and edges_lists[0]:
                 assert isinstance(edges_lists[0][0], self.edge_schema), (
                     "Invalid edge list format for batch merging"
                 )

--- a/hyperextract/types/hypergraph.py
+++ b/hyperextract/types/hypergraph.py
@@ -631,11 +631,14 @@ class AutoHypergraph(
                 logger.warning("stage=merge_batch_empty_tuple nodes_and_edges_empty")
                 return self.graph_schema(nodes=[], edges=[])
 
-            if nodes_lists:
+            # Guard against an empty first chunk: nodes_lists[0] (or edges_lists[0])
+            # can be an empty list when a chunk produced no nodes/edges, so
+            # indexing [0][0] without the inner check raises IndexError.
+            if nodes_lists and nodes_lists[0]:
                 assert isinstance(nodes_lists[0][0], self.node_schema), (
                     "Invalid node list format for batch merging"
                 )
-            if edges_lists:
+            if edges_lists and edges_lists[0]:
                 assert isinstance(edges_lists[0][0], self.edge_schema), (
                     "Invalid edge list format for batch merging"
                 )

--- a/tests/types/test_graph_dangling.py
+++ b/tests/types/test_graph_dangling.py
@@ -72,3 +72,34 @@ class TestAutoGraphMerge:
         ])
 
         assert len(graph.nodes) == 1
+
+    def test_merge_batch_data_empty_first_chunk(self, llm_client, embedder):
+        """merge_batch_data tolerates a chunk that produced no nodes/edges.
+
+        Previously the first sublist being empty raised IndexError via
+        nodes_lists[0][0] / edges_lists[0][0].
+        """
+        graph = AutoGraph(
+            node_schema=Entity,
+            edge_schema=Relation,
+            node_key_extractor=lambda x: x.name,
+            edge_key_extractor=lambda x: f"{x.source}-{x.relation_type}-{x.target}",
+            nodes_in_edge_extractor=lambda x: (x.source, x.target),
+            llm_client=llm_client,
+            embedder=embedder,
+        )
+
+        # First chunk produced nothing; the second carries the real data.
+        nodes_lists = [
+            [],
+            [Entity(name="Apple", type="ORGANIZATION", properties={})],
+        ]
+        edges_lists = [
+            [],
+            [Relation(source="Apple", target="Steve", relation_type="founded_by")],
+        ]
+
+        result = graph.merge_batch_data((nodes_lists, edges_lists))
+
+        assert {n.name for n in result.nodes} == {"Apple"}
+        assert len(result.edges) == 1

--- a/tests/types/test_hypergraph_merge.py
+++ b/tests/types/test_hypergraph_merge.py
@@ -1,0 +1,60 @@
+"""Unit tests for AutoHypergraph batch merge."""
+
+from typing import List
+
+from pydantic import BaseModel, Field
+
+from hyperextract.types import AutoHypergraph
+
+
+class Entity(BaseModel):
+    """Simple node schema for testing."""
+
+    name: str
+    type: str
+    properties: dict = Field(default_factory=dict)
+
+
+class HyperRelation(BaseModel):
+    """Simple hyperedge schema for testing."""
+
+    participants: List[str]
+    relation_type: str
+
+
+class TestAutoHypergraphMerge:
+    """Test cases for AutoHypergraph merge functionality."""
+
+    def _make_graph(self, llm_client, embedder):
+        return AutoHypergraph(
+            node_schema=Entity,
+            edge_schema=HyperRelation,
+            node_key_extractor=lambda x: x.name,
+            edge_key_extractor=lambda x: f"{x.relation_type}_{sorted(x.participants)}",
+            nodes_in_edge_extractor=lambda x: tuple(x.participants),
+            llm_client=llm_client,
+            embedder=embedder,
+        )
+
+    def test_merge_batch_data_empty_first_chunk(self, llm_client, embedder):
+        """merge_batch_data tolerates a chunk that produced no nodes/edges.
+
+        Previously the first sublist being empty raised IndexError via
+        nodes_lists[0][0] / edges_lists[0][0].
+        """
+        graph = self._make_graph(llm_client, embedder)
+
+        # First chunk produced nothing; the second carries the real data.
+        nodes_lists = [
+            [],
+            [Entity(name="Apple", type="ORGANIZATION", properties={})],
+        ]
+        edges_lists = [
+            [],
+            [HyperRelation(participants=["Apple", "Steve"], relation_type="founded_by")],
+        ]
+
+        result = graph.merge_batch_data((nodes_lists, edges_lists))
+
+        assert {n.name for n in result.nodes} == {"Apple"}
+        assert len(result.edges) == 1


### PR DESCRIPTION
## Problem
`merge_batch_data` in both `AutoGraph` and `AutoHypergraph` validates the tuple input by indexing the first element of the first sublist:

```python
if nodes_lists:
    assert isinstance(nodes_lists[0][0], self.node_schema), ...
if edges_lists:
    assert isinstance(edges_lists[0][0], self.edge_schema), ...
```

It only checks that the outer list is non-empty, not that `nodes_lists[0]` (or `edges_lists[0]`) is non-empty. When the first chunk produced no nodes/edges — e.g. `nodes_lists = [[], [...]]` — `nodes_lists[0][0]` raises `IndexError: list index out of range`, crashing the merge.

## Fix
Guard the inner access as well:

```python
if nodes_lists and nodes_lists[0]:
    assert isinstance(nodes_lists[0][0], self.node_schema), ...
if edges_lists and edges_lists[0]:
    assert isinstance(edges_lists[0][0], self.edge_schema), ...
```

Applied identically to `hyperextract/types/graph.py` and `hyperextract/types/hypergraph.py`.

## Tests
Added a test for each type that calls `merge_batch_data` with an empty first chunk and asserts the data from later chunks is still merged. Both were verified to fail (IndexError) on the pre-fix code and pass after.

`ruff check`/`ruff format --check` on `hyperextract` clean.
