### PR TITLE
fix: guard None chunk results in HyperGraph_RAG extraction

### DIFF
--- a/hyperextract/methods/rag/hypergraph_rag.py
+++ b/hyperextract/methods/rag/hypergraph_rag.py
@@ -267,11 +267,13 @@ class HyperGraph_RAG(AutoHypergraph[NodeSchema, EdgeSchema]):
 
         for raw_hyperedges in raw_hyperedges_list:
             cur_nodes, cur_edges = [], []
-            data_list = raw_hyperedges.items
-            for data in data_list:
-                data: EdgeSchema
-                cur_nodes.extend(data.related_entities)
-                cur_edges.append(data)
+            # batch()/invoke() can return None for a chunk when LLM extraction
+            # fails; guard before accessing .items (matches Atom / iText2KG_Star).
+            if raw_hyperedges and raw_hyperedges.items:
+                for data in raw_hyperedges.items:
+                    data: EdgeSchema
+                    cur_nodes.extend(data.related_entities)
+                    cur_edges.append(data)
             all_nodes_list.append(cur_nodes)
             all_edges_list.append(cur_edges)
 

--- a/tests/methods/test_hypergraph_rag.py
+++ b/tests/methods/test_hypergraph_rag.py
@@ -1,0 +1,27 @@
+"""Unit tests for HyperGraph_RAG extraction edge cases."""
+
+from unittest.mock import MagicMock
+
+from hyperextract.methods.rag import HyperGraph_RAG
+
+
+class TestHyperGraphRAGExtract:
+    """Test cases for HyperGraph_RAG._extract_data."""
+
+    def test_extract_data_handles_none_chunk(self, llm_client, embedder):
+        """A None result from the edge extractor must not crash extraction.
+
+        batch()/invoke() can return None when LLM extraction fails for a chunk.
+        Previously `_extract_data` accessed `raw_hyperedges.items` directly,
+        raising AttributeError on None.
+        """
+        graph = HyperGraph_RAG(llm_client=llm_client, embedder=embedder)
+
+        # Simulate the extractor failing for the (single) chunk.
+        graph.edge_extractor = MagicMock()
+        graph.edge_extractor.invoke.return_value = None
+
+        result = graph._extract_data("A short sentence.")
+
+        assert result.nodes == []
+        assert result.edges == []


### PR DESCRIPTION
## Problem
`HyperGraph_RAG._extract_data` iterates the per-chunk extractor results and accesses `.items` directly:

```python
for raw_hyperedges in raw_hyperedges_list:
    cur_nodes, cur_edges = [], []
    data_list = raw_hyperedges.items   # AttributeError if raw_hyperedges is None
    ...
```

`edge_extractor.batch()` / `invoke()` can return `None` for a chunk when LLM extraction fails (the same failure mode handled in #30). That makes `raw_hyperedges.items` raise `AttributeError: 'NoneType' object has no attribute 'items'`, crashing extraction.

The sibling extractors already guard this: `Atom` and `iText2KG_Star` both use `if edge_list and edge_list.items:` before iterating.

## Fix
Guard the access the same way:

```python
for raw_hyperedges in raw_hyperedges_list:
    cur_nodes, cur_edges = [], []
    if raw_hyperedges and raw_hyperedges.items:
        for data in raw_hyperedges.items:
            cur_nodes.extend(data.related_entities)
            cur_edges.append(data)
    all_nodes_list.append(cur_nodes)
    all_edges_list.append(cur_edges)
```

A failed chunk now contributes empty node/edge lists instead of crashing.

## Tests
Added `tests/methods/test_hypergraph_rag.py`: mocks the edge extractor to return `None` and asserts `_extract_data` returns an empty hypergraph rather than raising. Verified to fail (AttributeError) on the pre-fix code and pass after.

`ruff check`/`ruff format --check` on `hyperextract` clean.
