### PR TITLE
fix: restore datetime timestamps when loading metadata

### DIFF
--- a/hyperextract/types/base.py
+++ b/hyperextract/types/base.py
@@ -625,7 +625,21 @@ class BaseAutoType(ABC, Generic[T]):
         path = Path(file_path)
         with open(path, "r", encoding="utf-8") as f:
             params = json.load(f)
-            self.metadata.update(params)
+
+        # Timestamps are serialized as ISO strings (dump_metadata uses
+        # default=str). Restore them to datetime so a loaded instance behaves
+        # like a freshly created one; otherwise comparisons such as the
+        # min(created_at, ...) merge in __add__ raise TypeError when a loaded
+        # instance (str) is combined with a fresh one (datetime).
+        for key in ("created_at", "updated_at"):
+            value = params.get(key)
+            if isinstance(value, str):
+                try:
+                    params[key] = datetime.fromisoformat(value)
+                except ValueError:
+                    pass
+
+        self.metadata.update(params)
 
     @abstractmethod
     def dump_index(self, folder_path: str | Path) -> None:

--- a/tests/types/test_model_serialization.py
+++ b/tests/types/test_model_serialization.py
@@ -140,6 +140,36 @@ class TestAutoModelSerialization:
         assert "created_at" in new_model.metadata
         assert "updated_at" in new_model.metadata
 
+    def test_load_metadata_restores_datetime_type(self, llm_client, embedder):
+        """Loaded timestamps are datetime objects, not ISO strings.
+
+        dump_metadata serializes datetimes via default=str; without conversion
+        on load, a loaded instance keeps strings while a fresh one holds
+        datetimes, so min(created_at, ...) in __add__ would raise TypeError.
+        """
+        from datetime import datetime
+
+        model = AutoModel(
+            data_schema=PersonSchema,
+            llm_client=llm_client,
+            embedder=embedder,
+        )
+
+        metadata_file = Path(self.temp_dir) / "metadata.json"
+        model.dump_metadata(metadata_file)
+
+        new_model = AutoModel(
+            data_schema=PersonSchema,
+            llm_client=llm_client,
+            embedder=embedder,
+        )
+        new_model.load_metadata(metadata_file)
+
+        assert isinstance(new_model.metadata["created_at"], datetime)
+        assert isinstance(new_model.metadata["updated_at"], datetime)
+        # The real-world manifestation: comparing loaded vs fresh must not raise.
+        assert min(new_model.metadata["created_at"], datetime.now())
+
     @pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="Requires real LLM")
     def test_dump_and_load_full(self, llm_client, embedder):
         """Test full dump/load cycle."""


### PR DESCRIPTION
## Problem
`dump_metadata` serializes the metadata dict with `json.dump(..., default=str)`, so `created_at` / `updated_at` are written as ISO strings. `load_metadata` then does `self.metadata.update(params)` without converting them back, so a **loaded** instance holds `str` timestamps while a **freshly created** instance holds `datetime` objects.

This type inconsistency bites when the two are combined. `BaseAutoType.__add__` (and the type subclasses) compute:

```python
new.metadata["created_at"] = min(self.metadata["created_at"], other.metadata["created_at"])
```

Combining a loaded instance (str) with a fresh one (datetime) raises `TypeError: '<' not supported between instances of 'datetime.datetime' and 'str'`.

## Fix
In `load_metadata`, convert the known timestamp fields back to `datetime` via `datetime.fromisoformat` (guarded by try/except so unexpected formats are left untouched). Loaded instances now behave like freshly created ones.

## Tests
Added `test_load_metadata_restores_datetime_type`: dumps then loads metadata and asserts `created_at` / `updated_at` are `datetime`, and that `min(loaded_created_at, datetime.now())` does not raise. Verified to fail on the pre-fix code and pass after.

`ruff check`/`ruff format --check` on `hyperextract` clean.
