### PR TITLE
fix: use Optional type for non-required template fields

### DIFF
--- a/hyperextract/utils/template_engine/parsers/output.py
+++ b/hyperextract/utils/template_engine/parsers/output.py
@@ -1,6 +1,6 @@
 """Output schema parser."""
 
-from typing import List
+from typing import List, Optional
 from .schemas import (
     FieldSchema,
     NaiveOutputSchema,
@@ -33,8 +33,14 @@ def build_naive_schema(
             kwargs["default"] = field.default
         elif field.required is False:  # 非必填且无默认值时，设 default=None
             kwargs["default"] = None
+        # Use Optional type for non-required fields so None values pass validation
+        base_type = TYPE_MAPPING[field.type]
+        if field.required is False:
+            field_type = Optional[base_type]
+        else:
+            field_type = base_type
         schema_fields[field.name] = (
-            TYPE_MAPPING[field.type],
+            field_type,
             Field(**kwargs),
         )
     return create_model(name, __doc__=description, **schema_fields)


### PR DESCRIPTION
## Problem

When a YAML template defines a field with `required: false`, `build_naive_schema()` sets the Pydantic field type to the base type (`str`, `int`, etc.) but sets the default to `None`. Pydantic v2 raises a `ValidationError` whenever the LLM returns `null` for that field, because `None` is not valid for a non-Optional type.

This affects all templates with optional fields — including the built-in `industry/equipment_topology` template where fields like `location` are commonly returned as `null`.

## Fix

Wrap the base type in `Optional` when `field.required is False`, so `None` values from the LLM pass validation cleanly.

```python
# Before
schema_fields[field.name] = (TYPE_MAPPING[field.type], Field(**kwargs))

# After
base_type = TYPE_MAPPING[field.type]
field_type = Optional[base_type] if field.required is False else base_type
schema_fields[field.name] = (field_type, Field(**kwargs))
```

## Tested on

- `industry/equipment_topology` template against 3 instrumentation PDFs (Fisher DVC6200, Rosemount 3144P, Micro Motion ELITE Coriolis)
- v0.3.0, Python 3.14, Pydantic v2