### PR TITLE
fix: localize guideline section labels by template language

### DIFF
--- a/hyperextract/utils/template_engine/factory.py
+++ b/hyperextract/utils/template_engine/factory.py
@@ -98,7 +98,7 @@ class TemplateFactory:
         from hyperextract.types import AutoModel
 
         data_schema = parse_output(config.output, config.type)
-        prompt = parse_guideline(config.guideline, config.type)
+        prompt = parse_guideline(config.guideline, config.type, config.language)
         options = parse_option(config.options, config.type, override=kwargs)
         label_extractor = parse_display(config.display, config.type)
 
@@ -123,7 +123,7 @@ class TemplateFactory:
         from hyperextract.types import AutoList
 
         data_schema = parse_output(config.output, config.type)
-        prompt = parse_guideline(config.guideline, config.type)
+        prompt = parse_guideline(config.guideline, config.type, config.language)
         options = parse_option(config.options, config.type, override=kwargs)
         item_label_extractor = parse_display(config.display, config.type)
 
@@ -149,7 +149,7 @@ class TemplateFactory:
 
         data_schema = parse_output(config.output, config.type)
         item_id_extractor = parse_identifiers(config.identifiers, config.type)
-        prompt = parse_guideline(config.guideline, config.type)
+        prompt = parse_guideline(config.guideline, config.type, config.language)
         options = parse_option(config.options, config.type, override=kwargs)
         item_label_extractor = parse_display(config.display, config.type)
 
@@ -180,7 +180,7 @@ class TemplateFactory:
             identifiers
         )
         prompt, prompt_for_entity_extraction, prompt_for_relation_extraction = (
-            parse_guideline(config.guideline, config.type)
+            parse_guideline(config.guideline, config.type, config.language)
         )
         node_label_extractor, edge_label_extractor = parse_display(
             config.display, config.type
@@ -220,7 +220,7 @@ class TemplateFactory:
             identifiers
         )
         prompt, prompt_for_entity_extraction, prompt_for_relation_extraction = (
-            parse_guideline(config.guideline, config.type)
+            parse_guideline(config.guideline, config.type, config.language)
         )
         node_label_extractor, edge_label_extractor = parse_display(
             config.display, config.type
@@ -262,7 +262,7 @@ class TemplateFactory:
         ) = parse_identifiers(config.identifiers, config.type)
 
         prompt, prompt_for_entity_extraction, prompt_for_relation_extraction = (
-            parse_guideline(config.guideline, config.type)
+            parse_guideline(config.guideline, config.type, config.language)
         )
         node_label_extractor, edge_label_extractor = parse_display(
             config.display, config.type
@@ -306,7 +306,7 @@ class TemplateFactory:
             location_in_edge_extractor,
         ) = identifiers
         prompt, prompt_for_entity_extraction, prompt_for_relation_extraction = (
-            parse_guideline(config.guideline, config.type)
+            parse_guideline(config.guideline, config.type, config.language)
         )
         node_label_extractor, edge_label_extractor = parse_display(
             config.display, config.type
@@ -351,7 +351,7 @@ class TemplateFactory:
             location_in_edge_extractor,
         ) = identifiers
         prompt, prompt_for_entity_extraction, prompt_for_relation_extraction = (
-            parse_guideline(config.guideline, config.type)
+            parse_guideline(config.guideline, config.type, config.language)
         )
         node_label_extractor, edge_label_extractor = parse_display(
             config.display, config.type

--- a/hyperextract/utils/template_engine/parsers/guideline.py
+++ b/hyperextract/utils/template_engine/parsers/guideline.py
@@ -27,19 +27,22 @@ LABEL_MAPPING = {
 }
 
 
-def parse_guideline(guideline, autotype: str) -> str | Tuple[str, str, str]:
+def parse_guideline(
+    guideline, autotype: str, language: str = "en"
+) -> str | Tuple[str, str, str]:
     """Parse guideline and return prompts based on autotype (config is already localized).
 
     Args:
         guideline: Guideline instance (single-language, all fields are strings)
         autotype: Template type (default: "model")
+        language: Language for the section labels (falls back to "en").
 
     Returns:
         tuple: main_prompt or (main_prompt, node_prompt, edge_prompt)
         - For non-graph types: returns main_prompt
         - For graph types in two_stage mode: returns (main_prompt, node_prompt, edge_prompt)
     """
-    labels = LABEL_MAPPING.get("zh", LABEL_MAPPING["en"])
+    labels = LABEL_MAPPING.get(language, LABEL_MAPPING["en"])
 
     prefix_prompt = f"# {labels.get('role_and_task')}:\n{guideline.target}"
 

--- a/tests/template_engine/test_parser_guideline.py
+++ b/tests/template_engine/test_parser_guideline.py
@@ -1,0 +1,25 @@
+"""Tests for parse_guideline label localization."""
+
+from types import SimpleNamespace
+
+from hyperextract.utils.template_engine.parsers.guideline import parse_guideline
+
+
+def _guideline():
+    return SimpleNamespace(target="Extract people", rules="Be precise")
+
+
+def test_labels_follow_language():
+    """Section labels use the given language, not a hardcoded one."""
+    en = parse_guideline(_guideline(), "model", "en")
+    assert "Role and Task" in en
+    assert "角色与任务" not in en
+
+    zh = parse_guideline(_guideline(), "model", "zh")
+    assert "角色与任务" in zh
+    assert "Role and Task" not in zh
+
+
+def test_unknown_language_falls_back_to_en():
+    out = parse_guideline(_guideline(), "model", "fr")
+    assert "Role and Task" in out


### PR DESCRIPTION
## Problem
`parse_guideline` built prompt section labels from a hardcoded language:

```python
labels = LABEL_MAPPING.get("zh", LABEL_MAPPING["en"])
```

So every template — regardless of its language — got Chinese section headers (`# 角色与任务:`, `## 提取规则:`, `## 源文本:`). An English template produced English content under Chinese headers. The unused `LABEL_MAPPING["en"]` fallback shows the label language was meant to vary.

## Fix
Pass the template language into `parse_guideline` and select labels by it:

```python
def parse_guideline(guideline, autotype, language="en"):
    labels = LABEL_MAPPING.get(language, LABEL_MAPPING["en"])
```

The 8 call sites in `factory.py` now pass `config.language`, which `localize_template` already sets to the single target language. Unknown languages fall back to English.

## Tests
Added `tests/template_engine/test_parser_guideline.py`: asserts `en` yields English labels, `zh` yields Chinese, and an unknown language falls back to English. Existing `test_factory.py` still passes, confirming the call-site changes are compatible.

`ruff check`/`ruff format --check` on `hyperextract` clean.
