### PR TITLE
fix: guarantee _localize_data returns str for missing language

### DIFF
--- a/hyperextract/utils/template_engine/parsers/loader.py
+++ b/hyperextract/utils/template_engine/parsers/loader.py
@@ -54,11 +54,14 @@ def _localize_data(
         return value
     if isinstance(value, list):
         return "\n".join(f"{i + 1}. {item}" for i, item in enumerate(value))
-    dict_value = value.get(language)
+    # Fall back to English (then empty) when the requested language is absent,
+    # so the return is always a str — a missing key otherwise returns None.
+    dict_value = value.get(language, value.get("en"))
     if isinstance(dict_value, str):
         return dict_value
     if isinstance(dict_value, list):
         return "\n".join(f"{i + 1}. {item}" for i, item in enumerate(dict_value))
+    return ""
 
 
 def _localize_field(field: FieldSchema, language: str) -> FieldSchema:

--- a/tests/template_engine/test_parser_loader.py
+++ b/tests/template_engine/test_parser_loader.py
@@ -8,6 +8,20 @@ from pathlib import Path
 from hyperextract.utils.template_engine.parsers import (
     load_template,
 )
+from hyperextract.utils.template_engine.parsers.loader import _localize_data
+
+
+class TestLocalizeData:
+    """_localize_data always returns a str, even for a missing language."""
+
+    def test_missing_language_falls_back_to_en(self):
+        assert _localize_data({"en": "Hello"}, "zh") == "Hello"
+
+    def test_missing_language_and_no_en_returns_empty(self):
+        assert _localize_data({"fr": "Bonjour"}, "zh") == ""
+
+    def test_present_language_used(self):
+        assert _localize_data({"en": "Hello", "zh": "你好"}, "zh") == "你好"
 
 
 class TestLoadTemplate:


### PR DESCRIPTION
## Problem
`_localize_data` is annotated `-> str`, but for a dict-valued field it only returns when the requested language key is present and maps to str/list:

```python
dict_value = value.get(language)
if isinstance(dict_value, str):
    return dict_value
if isinstance(dict_value, list):
    return "\n".join(...)
# falls through -> returns None
```

When a multilingual field (e.g. `description: {en: "..."}`) is localized to a language it lacks — reachable via `factory.create(source, language)` / `he parse -l <lang>` with a language the template field doesn't declare — it returns `None`. That `None` then flows into descriptions, guideline rules, and field docs, corrupting prompts or failing schema construction.

## Fix
Fall back to English, then empty string, so the return is always a str — matching the existing convention in `cli/commands/list.py` (`desc.get(lang, desc.get("en", ""))`):

```python
dict_value = value.get(language, value.get("en"))
if isinstance(dict_value, str):
    return dict_value
if isinstance(dict_value, list):
    return "\n".join(...)
return ""
```

Fixing the shared helper covers every localize call site at once.

## Tests
Added `TestLocalizeData` in `tests/template_engine/test_parser_loader.py`: missing language falls back to `en`, missing with no `en` returns `""`, present language is used. The two fallback tests fail on the pre-fix code.

`ruff check`/`ruff format --check` on `hyperextract` clean.
