### PR TITLE
fix: accept TemplateCfg instance as create() source

### DIFF
--- a/hyperextract/utils/template_engine/factory.py
+++ b/hyperextract/utils/template_engine/factory.py
@@ -455,6 +455,8 @@ class TemplateFactory:
                 template_cfg = load_template(s)
             case str() as s:
                 template_cfg = Gallery.get(s)
+            case TemplateCfg() as cfg:
+                template_cfg = cfg
             case _:
                 raise ValueError("Invalid source: must be a template path or file path")
 
@@ -493,10 +495,12 @@ class TemplateFactory:
                     template_cfg, llm_client, embedder, **kwargs
                 )
 
-        if source.endswith(".yaml"):
-            template.metadata["template"] = Path(source).stem
+        if isinstance(source, str):
+            template.metadata["template"] = (
+                Path(source).stem if source.endswith(".yaml") else source
+            )
         else:
-            template.metadata["template"] = source
+            template.metadata["template"] = source.name
         template.metadata["lang"] = language
         template.metadata["type"] = template_cfg.type
 

--- a/tests/template_engine/test_factory.py
+++ b/tests/template_engine/test_factory.py
@@ -47,6 +47,16 @@ class TestTemplateFactoryCreateMethod:
                 embedder=embedder,
             )
 
+    def test_create_from_templatecfg_instance(self, llm_client, embedder):
+        """create() accepts a TemplateCfg instance (documented + typed source)."""
+        cfg = Gallery.get("general/model")
+
+        result = TemplateFactory.create(cfg, "en", llm_client, embedder)
+
+        assert result is not None
+        assert result.metadata["template"] == cfg.name
+        assert result.metadata["lang"] == "en"
+
     def test_create_method_template(self, llm_client, embedder):
         """Test creating a method template."""
         result = TemplateFactory.create(


### PR DESCRIPTION
## Problem
`TemplateFactory.create` is typed `source: Union[str, TemplateCfg]` and its docstring shows `create(config, "zh", llm, embedder)`, but the `match source:` block only handles `str` and falls through to:

```python
case _:
    raise ValueError("Invalid source: must be a template path or file path")
```

So passing a `TemplateCfg` — a documented, type-hinted input — raises `ValueError`. And even past that, the later `source.endswith(".yaml")` would `AttributeError` on a non-str source.

## Fix
- Add `case TemplateCfg() as cfg: template_cfg = cfg` to the match.
- Guard the metadata assignment so `endswith` only runs for `str` sources; use `source.name` for a `TemplateCfg`.

## Tests
Added `test_create_from_templatecfg_instance`: obtains a `TemplateCfg` via `Gallery.get(...)`, passes it to `create()`, and checks the result plus `metadata["template"]`/`metadata["lang"]`. Fails on the pre-fix code.

`ruff check`/`ruff format --check` on `hyperextract` clean.
