### PR TITLE
fix: use function_calling for structured output on non-OpenAI providers (#52)

### DIFF
--- a/hyperextract/methods/typical/atom.py
+++ b/hyperextract/methods/typical/atom.py
@@ -433,7 +433,7 @@ class Atom(AutoGraph[NodeSchema, EdgeSchema]):
             Atom_FACTOID_EXTRACTION_PROMPT
         )
         fact_chain = fact_prompt_template | self.llm_client.with_structured_output(
-            AtomicFactSchema
+            AtomicFactSchema, method="function_calling"
         )
 
         # 3. Batch Extract Facts

--- a/hyperextract/types/base.py
+++ b/hyperextract/types/base.py
@@ -76,7 +76,9 @@ class BaseAutoType(ABC, Generic[T]):
         self.prompt_template = ChatPromptTemplate.from_template(self.prompt)
         self.data_extractor = (
             self.prompt_template
-            | self.llm_client.with_structured_output(self._data_schema)
+            | self.llm_client.with_structured_output(
+                self._data_schema, method="function_calling"
+            )
         )
 
         # Initialize text splitter for chunking long documents

--- a/hyperextract/types/graph.py
+++ b/hyperextract/types/graph.py
@@ -316,13 +316,17 @@ class AutoGraph(
         self.prompt_template = ChatPromptTemplate.from_template(self.node_prompt)
         self.node_extractor = (
             self.prompt_template
-            | self.llm_client.with_structured_output(self.node_list_schema)
+            | self.llm_client.with_structured_output(
+                self.node_list_schema, method="function_calling"
+            )
         )
 
         self.edge_prompt_template = ChatPromptTemplate.from_template(self.edge_prompt)
         self.edge_extractor = (
             self.edge_prompt_template
-            | self.llm_client.with_structured_output(self.edge_list_schema)
+            | self.llm_client.with_structured_output(
+                self.edge_list_schema, method="function_calling"
+            )
         )
 
     def _default_prompt(self) -> str:

--- a/hyperextract/types/hypergraph.py
+++ b/hyperextract/types/hypergraph.py
@@ -321,13 +321,17 @@ class AutoHypergraph(
         self.prompt_template = ChatPromptTemplate.from_template(self.node_prompt)
         self.node_extractor = (
             self.prompt_template
-            | self.llm_client.with_structured_output(self.node_list_schema)
+            | self.llm_client.with_structured_output(
+                self.node_list_schema, method="function_calling"
+            )
         )
 
         self.edge_prompt_template = ChatPromptTemplate.from_template(self.edge_prompt)
         self.edge_extractor = (
             self.edge_prompt_template
-            | self.llm_client.with_structured_output(self.edge_list_schema)
+            | self.llm_client.with_structured_output(
+                self.edge_list_schema, method="function_calling"
+            )
         )
 
     # ==================== Prompts ====================

--- a/tests/types/test_structured_output_method.py
+++ b/tests/types/test_structured_output_method.py
@@ -1,0 +1,58 @@
+"""Structured extraction must request method="function_calling" (issue #52).
+
+langchain-openai defaults to method="json_schema", which only OpenAI supports;
+DeepSeek / vLLM / Ollama and other OpenAI-compatible endpoints reject it.
+"""
+
+from pydantic import BaseModel
+
+from tests.mocks import MockEmbeddings, MockStructuredRunnable
+from hyperextract.types import AutoModel, AutoGraph
+
+
+class _Person(BaseModel):
+    name: str
+
+
+class _Entity(BaseModel):
+    name: str
+    type: str = "x"
+
+
+class _Relation(BaseModel):
+    source: str
+    target: str
+
+
+class _SpyLLM:
+    """Records the `method` passed to each with_structured_output call."""
+
+    def __init__(self):
+        self.captured = []
+
+    def with_structured_output(self, schema, **kwargs):
+        self.captured.append(kwargs.get("method"))
+        return MockStructuredRunnable(schema=schema)
+
+
+def test_automodel_requests_function_calling():
+    spy = _SpyLLM()
+    AutoModel(data_schema=_Person, llm_client=spy, embedder=MockEmbeddings())
+    assert spy.captured
+    assert all(m == "function_calling" for m in spy.captured)
+
+
+def test_autograph_two_stage_requests_function_calling():
+    spy = _SpyLLM()
+    AutoGraph(
+        node_schema=_Entity,
+        edge_schema=_Relation,
+        node_key_extractor=lambda x: x.name,
+        edge_key_extractor=lambda x: f"{x.source}-{x.target}",
+        nodes_in_edge_extractor=lambda x: (x.source, x.target),
+        llm_client=spy,
+        embedder=MockEmbeddings(),
+        extraction_mode="two_stage",
+    )
+    assert spy.captured
+    assert all(m == "function_calling" for m in spy.captured)


### PR DESCRIPTION
Fixes #52.

## Problem
`langchain-openai` changed the default `method` of `ChatOpenAI.with_structured_output(schema)` from `function_calling` to `json_schema` (which sends `response_format: {"type": "json_schema", ...}`). That format is OpenAI-proprietary — DeepSeek, vLLM, Ollama, LiteLLM and other OpenAI-compatible endpoints reject it, so structured extraction fails on every non-OpenAI provider.

Six of the seven `with_structured_output` call sites relied on that default; `graph_rag.py` already passed `method="function_calling"` explicitly.

## Fix
Pass `method="function_calling"` at the remaining six call sites, matching the existing `graph_rag.py` usage. `function_calling` (tool calling) is the universally supported method — including on OpenAI — so it restores extraction across all providers.

Call sites updated: `types/base.py`, `types/graph.py` (node + edge), `types/hypergraph.py` (node + edge), `methods/typical/atom.py`.

## Tests
`tests/types/test_structured_output_method.py`: a spy LLM records the `method` passed during extractor construction. Asserts `AutoModel` and two-stage `AutoGraph` both request `function_calling`. Both fail on the pre-fix code.

`ruff check`/`ruff format --check` on `hyperextract` clean.
