### PR TITLE
fix: tolerate LLM parse failures during extraction (#45)

### DIFF
--- a/hyperextract/types/base.py
+++ b/hyperextract/types/base.py
@@ -257,7 +257,13 @@ class BaseAutoType(ABC, Generic[T]):
 
         if len(text) <= self.chunk_size:
             logger.debug("stage=extract_single_chunk chunk_text_preview=%s", text[:200])
-            extracted_data = self.data_extractor.invoke({"source_text": text})
+            try:
+                extracted_data = self.data_extractor.invoke({"source_text": text})
+            except Exception as e:
+                # LLM returned unparseable output (e.g. prose instead of JSON).
+                # Log and treat as an empty result instead of crashing the run.
+                logger.warning("stage=extract_single_chunk_failed error=%s", e)
+                extracted_data = None
             logger.debug(
                 "stage=extract_single_chunk_result chunk=0 result_summary=%s",
                 self._summarize_extracted(extracted_data),
@@ -279,9 +285,22 @@ class BaseAutoType(ABC, Generic[T]):
                 self.max_workers,
                 len(inputs),
             )
+            # return_exceptions keeps one bad chunk from aborting the whole batch;
+            # failures are logged and nulled (then filtered) below.
             extracted_data_list = self.data_extractor.batch(
-                inputs, config={"max_concurrency": self.max_workers}
+                inputs,
+                config={"max_concurrency": self.max_workers},
+                return_exceptions=True,
             )
+            cleaned = []
+            for i, r in enumerate(extracted_data_list):
+                if isinstance(r, Exception):
+                    logger.warning(
+                        "stage=chunk_extract_failed chunk_index=%d error=%s", i, r
+                    )
+                    r = None
+                cleaned.append(r)
+            extracted_data_list = cleaned
             logger.debug(
                 "stage=llm_batch_complete results=%d", len(extracted_data_list)
             )

--- a/tests/types/test_forgiving_extraction.py
+++ b/tests/types/test_forgiving_extraction.py
@@ -1,0 +1,43 @@
+"""Extraction tolerates LLM parse failures instead of crashing (issue #45)."""
+
+from pydantic import BaseModel
+
+from tests.mocks import MockChatModel, MockEmbeddings
+from hyperextract.types import AutoModel
+
+
+class _Person(BaseModel):
+    name: str = ""
+
+
+class _BoomExtractor:
+    """Stands in for a data_extractor whose LLM returns unparseable output."""
+
+    def invoke(self, _input, config=None):
+        raise ValueError("Invalid JSON: expected value at line 1 column 1")
+
+    def batch(self, inputs, config=None, return_exceptions=False, **kwargs):
+        errs = [ValueError("Invalid JSON") for _ in inputs]
+        if return_exceptions:
+            return errs
+        raise errs[0]
+
+
+def _model():
+    m = AutoModel(
+        data_schema=_Person, llm_client=MockChatModel(), embedder=MockEmbeddings()
+    )
+    m.data_extractor = _BoomExtractor()
+    return m
+
+
+def test_parse_survives_single_chunk_failure():
+    # text <= chunk_size -> invoke() path; a parse error yields an empty result
+    result = _model().parse("short text")
+    assert result.empty()
+
+
+def test_parse_survives_multi_chunk_failure():
+    # text > chunk_size -> batch() path
+    result = _model().parse("sentence. " * 400)
+    assert result.empty()


### PR DESCRIPTION
Fixes #45.

## Problem
When the LLM returns output that can't be parsed into the target schema (e.g. a prose preamble instead of JSON), extraction raises `ValidationError` and the entire run crashes. There's no logging of what the model actually produced, so the failure is hard to diagnose.

`_extract_data` already tolerates `None` results from `batch()` (via `_filter_none_results`), but:
- the single-chunk `invoke()` path had no error handling at all, and
- `batch()` propagates exceptions by default, so one bad chunk aborts the whole batch.

## Fix
Make `_extract_data` forgiving:
- Wrap the single-chunk `invoke()` in try/except — log a warning and treat the chunk as an empty (`None`) result.
- Call `batch(..., return_exceptions=True)` and convert per-chunk exceptions to `None`, logging each one.

Failed chunks then flow through the existing `_filter_none_results` path, so a bad response yields an empty result (and a logged warning naming the error) instead of crashing. This addresses both asks in the issue: a more forgiving pipeline and logging to trace what the LLM got wrong.

## Tests
`tests/types/test_forgiving_extraction.py`: with an extractor that always fails to parse, `parse()` returns an empty instance instead of raising — covered for both the single-chunk (`invoke`) and multi-chunk (`batch`) paths. Both fail on the pre-fix code.

`ruff check`/`ruff format --check` on `hyperextract` clean.

Note: retry is intentionally left out — the graceful-skip + logging behavior covers the reported need; an automatic retry wrapper can be added later if useful.
