### PR TITLE
fix: create custom config parent dir on save, not the default dir

### DIFF
--- a/hyperextract/cli/config.py
+++ b/hyperextract/cli/config.py
@@ -135,7 +135,9 @@ class ConfigManager:
 
     def _save(self) -> None:
         """Save configuration to file."""
-        DEFAULT_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        # Create the parent of the actual target path, not the default dir —
+        # a custom config_path may live elsewhere and would otherwise 404.
+        self.config_path.parent.mkdir(parents=True, exist_ok=True)
 
         data = {
             "llm": self.llm.to_dict(),

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -1,0 +1,17 @@
+"""Tests for ConfigManager persistence."""
+
+from hyperextract.cli.config import ConfigManager
+
+
+def test_save_creates_custom_parent_dir(tmp_path):
+    """_save() must create the parent of a custom config_path, not the default dir."""
+    cfg_path = tmp_path / "nested" / "dir" / "config.toml"  # parent doesn't exist yet
+
+    mgr = ConfigManager(cfg_path)
+    mgr.set_llm(provider="openai", model="gpt-4o-mini", api_key="sk-x")
+
+    assert cfg_path.exists()
+
+    # Round-trips back through a fresh manager.
+    reloaded = ConfigManager(cfg_path)
+    assert reloaded.llm.model == "gpt-4o-mini"


### PR DESCRIPTION
## Problem
`ConfigManager` honors a custom `config_path` (`self.config_path = config_path or DEFAULT_CONFIG_FILE`), but `_save()` creates the wrong directory:

```python
def _save(self) -> None:
    DEFAULT_CONFIG_DIR.mkdir(parents=True, exist_ok=True)   # always ~/.he
    ...
    with open(self.config_path, "wb") as f:                 # writes elsewhere
```

When `config_path` points somewhere whose parent doesn't exist, `open(self.config_path, "wb")` raises `FileNotFoundError`. It also has the side effect of creating `~/.he` even when a custom path is used. This is reachable through the public API, e.g. `get_client(config_path=...)` → `ConfigManager(custom_path)` → `set_llm(...)`.

## Fix
Create the parent of the actual target path:

```python
self.config_path.parent.mkdir(parents=True, exist_ok=True)
```

## Tests
`tests/cli/test_config.py`: saving to a nested custom `config_path` whose parent doesn't exist creates the file and round-trips through a fresh `ConfigManager`. Fails with `FileNotFoundError` on the pre-fix code.

`ruff check`/`ruff format --check` on `hyperextract` clean.
