### PR TITLE
fix: filter None chunk results in graph merge_batch_data

### DIFF
--- a/hyperextract/types/graph.py
+++ b/hyperextract/types/graph.py
@@ -692,6 +692,13 @@ class AutoGraph(
             logger.warning("stage=merge_batch_empty input_is_empty")
             return self.graph_schema(nodes=[], edges=[])
 
+        # Drop failed (None) chunk results from the list form; otherwise a single
+        # failed invoke() ([None]) falls through to the tuple branch and asserts.
+        if isinstance(data_list_or_tuple, list):
+            data_list_or_tuple = [g for g in data_list_or_tuple if g is not None]
+            if not data_list_or_tuple:
+                return self.graph_schema(nodes=[], edges=[])
+
         logger.debug(
             "stage=merge_batch_start input_type=%s",
             "tuple"

--- a/hyperextract/types/hypergraph.py
+++ b/hyperextract/types/hypergraph.py
@@ -613,6 +613,13 @@ class AutoHypergraph(
             logger.warning("stage=merge_batch_empty input_is_empty")
             return self.graph_schema(nodes=[], edges=[])
 
+        # Drop failed (None) chunk results from the list form; otherwise a single
+        # failed invoke() ([None]) falls through to the tuple branch and asserts.
+        if isinstance(data_list_or_tuple, list):
+            data_list_or_tuple = [g for g in data_list_or_tuple if g is not None]
+            if not data_list_or_tuple:
+                return self.graph_schema(nodes=[], edges=[])
+
         if isinstance(data_list_or_tuple, list) and isinstance(
             data_list_or_tuple[0], self.graph_schema
         ):

--- a/tests/types/test_graph_dangling.py
+++ b/tests/types/test_graph_dangling.py
@@ -73,6 +73,27 @@ class TestAutoGraphMerge:
 
         assert len(graph.nodes) == 1
 
+    def test_merge_batch_data_filters_none(self, llm_client, embedder):
+        """A failed single-chunk invoke ([None]) yields an empty graph.
+
+        Previously [None] fell through to the tuple branch and raised
+        AssertionError instead of degrading gracefully.
+        """
+        graph = AutoGraph(
+            node_schema=Entity,
+            edge_schema=Relation,
+            node_key_extractor=lambda x: x.name,
+            edge_key_extractor=lambda x: f"{x.source}-{x.relation_type}-{x.target}",
+            nodes_in_edge_extractor=lambda x: (x.source, x.target),
+            llm_client=llm_client,
+            embedder=embedder,
+        )
+
+        result = graph.merge_batch_data([None])
+
+        assert result.nodes == []
+        assert result.edges == []
+
     def test_merge_batch_data_empty_first_chunk(self, llm_client, embedder):
         """merge_batch_data tolerates a chunk that produced no nodes/edges.
 

--- a/tests/types/test_hypergraph_merge.py
+++ b/tests/types/test_hypergraph_merge.py
@@ -58,3 +58,12 @@ class TestAutoHypergraphMerge:
 
         assert {n.name for n in result.nodes} == {"Apple"}
         assert len(result.edges) == 1
+
+    def test_merge_batch_data_filters_none(self, llm_client, embedder):
+        """A failed single-chunk invoke ([None]) yields an empty hypergraph."""
+        graph = self._make_graph(llm_client, embedder)
+
+        result = graph.merge_batch_data([None])
+
+        assert result.nodes == []
+        assert result.edges == []


### PR DESCRIPTION
## Problem
In one-stage extraction, the single-chunk path does:

```python
graph = self.data_extractor.invoke(inp)
graph_list = [graph]
... merge_batch_data(graph_list)
```

`with_structured_output(method="function_calling")` can return `None` when the model emits no tool call. `merge_batch_data([None])` then falls through to the tuple branch and hits `assert len(data_list_or_tuple) == 2`, raising `AssertionError` instead of degrading gracefully. (The multi-chunk `batch` path already filters None via `_filter_none_results`; the single-chunk path did not.)

This affects `AutoGraph`, `AutoHypergraph`, and the three specialized graphs (`AutoTemporalGraph`, `AutoSpatialGraph`, `AutoSpatioTemporalGraph`), which all inherit `merge_batch_data`.

## Fix
Filter `None` entries from the list form at the top of `merge_batch_data` (in `graph.py` and `hypergraph.py` — the only two definitions). An all-`None` list returns an empty graph. The tuple form (`(nodes_lists, edges_lists)`) is a tuple, not a list, so it's unaffected. Fixing this one chokepoint covers all five graph types.

## Tests
`merge_batch_data([None])` returns an empty graph/hypergraph instead of raising, for both `AutoGraph` and `AutoHypergraph`. Both fail with `AssertionError` on the pre-fix code.

`ruff check`/`ruff format --check` on `hyperextract` clean.
