### PR TITLE
fix: Graph_RAG.search returns 3-tuple in default mode too

### DIFF
--- a/hyperextract/methods/rag/graph_rag.py
+++ b/hyperextract/methods/rag/graph_rag.py
@@ -560,7 +560,9 @@ class Graph_RAG(AutoGraph[NodeSchema, EdgeSchema]):
         """
         if use_community:
             return self._global_search_impl(query, top_k_nodes, top_k_edges)
-        return super().search(query, top_k_nodes, top_k_edges, top_k)
+        # Keep the 3-tuple contract: no community context in the default path.
+        nodes, edges = super().search(query, top_k_nodes, top_k_edges, top_k)
+        return nodes, edges, None
 
     def _global_search_impl(
         self,

--- a/hyperextract/types/graph.py
+++ b/hyperextract/types/graph.py
@@ -1023,11 +1023,15 @@ class AutoGraph(
             )
 
             def search_callback(query: str) -> None:
-                return self.search(
+                # search() may return (nodes, edges) or, in subclasses like
+                # Graph_RAG, (nodes, edges, context); ontosight only wants the
+                # first two.
+                result = self.search(
                     query,
                     top_k_nodes=top_k_nodes_for_search,
                     top_k_edges=top_k_edges_for_search,
                 )
+                return result[0], result[1]
 
             def chat_callback(question: str) -> None:
                 response = self.chat(

--- a/tests/methods/test_graph_rag.py
+++ b/tests/methods/test_graph_rag.py
@@ -1,0 +1,24 @@
+"""Tests for Graph_RAG.search return contract."""
+
+from tests.mocks import MockChatModel, MockEmbeddings
+from hyperextract.methods.rag import Graph_RAG
+from hyperextract.methods.rag.graph_rag import NodeSchema, EdgeSchema
+
+
+def _rag():
+    rag = Graph_RAG(llm_client=MockChatModel(), embedder=MockEmbeddings())
+    rag._node_memory.add([NodeSchema(name="Apple", type="org", description="d")])
+    rag._edge_memory.add(
+        [EdgeSchema(source="Apple", target="Steve", description="d", strength=5)]
+    )
+    rag.build_index()
+    return rag
+
+
+def test_search_default_returns_three_tuple():
+    """Default (use_community=False) search must match the 3-tuple contract."""
+    result = _rag().search("Apple")
+
+    assert len(result) == 3
+    nodes, edges, context = result  # must not raise
+    assert context is None


### PR DESCRIPTION
## Problem
`Graph_RAG.search` is annotated `-> tuple[list, list, dict | None]` and its docstring says it returns `(nodes, edges, community_context)` with `community_context = None` when `use_community=False`. The `use_community=True` branch returns a 3-tuple, but the default branch returns `super().search(...)` — a **2-tuple**.

Following the documented contract in default mode crashes:

```python
nodes, edges, ctx = rag.search(query)   # ValueError: not enough values to unpack (expected 3, got 2)
```

## Fix
- Default branch now returns `(nodes, edges, None)`, matching the signature, the docstring, and the community branch.
- The shared `AutoGraph.show()` search callback now returns exactly `(nodes, edges)` so ontosight's visualization is unaffected by `search()`'s arity (a no-op for every non-`Graph_RAG` graph, which already return 2-tuples).

## Tests
`tests/methods/test_graph_rag.py`: default `search()` returns a 3-tuple with `context is None`. Fails (2-tuple) on the pre-fix code. Existing `test_graph_search` still passes.

`ruff check`/`ruff format --check` on `hyperextract` clean.
