### PR TITLE
fix: honor relation_members field mapping and preserve edge direction

### DIFF
--- a/hyperextract/templates/DESIGN_GUIDE.md
+++ b/hyperextract/templates/DESIGN_GUIDE.md
@@ -571,6 +571,10 @@ identifiers:
     target: target
 ```
 
+The dict values name the relation fields that hold each endpoint, so custom
+field names work too (e.g. `source: subject` / `target: object`). Endpoint
+order is preserved as `(source, target)` for directed edges.
+
 #### For hypergraph (simple)
 
 ```yaml

--- a/hyperextract/templates/DESIGN_GUIDE_zh.md
+++ b/hyperextract/templates/DESIGN_GUIDE_zh.md
@@ -571,6 +571,10 @@ identifiers:
     target: target
 ```
 
+字典的值指向关系中存放两个端点的字段名，因此自定义字段名同样有效
+（例如 `source: subject` / `target: object`）。有向边的端点顺序保持为
+`(source, target)`。
+
 #### hypergraph（简单）
 
 ```yaml

--- a/hyperextract/utils/template_engine/parsers/identifiers.py
+++ b/hyperextract/utils/template_engine/parsers/identifiers.py
@@ -49,17 +49,18 @@ def _members_extractor(
     Hypergraph: 'members' -> lambda x: tuple(sorted(x.members)) or
                 'members' -> lambda x: tuple(sorted(x.m) for m in x.members)
     """
-    # Handle Graph
+    # Handle Graph: preserve (source, target) order for directed edges
     if isinstance(members, dict):
+        source_field = members["source"]
+        target_field = members["target"]
 
         def extractor(item: Any) -> tuple[str, str]:
-            return tuple(
-                sorted(
-                    [
-                        str(item.source),
-                        str(item.target),
-                    ]
-                )
+            missing = [f for f in (source_field, target_field) if not hasattr(item, f)]
+            if missing:
+                raise AttributeError(f"Missing fields: {missing}")
+            return (
+                str(getattr(item, source_field)),
+                str(getattr(item, target_field)),
             )
 
         return extractor

--- a/tests/template_engine/test_parser_identifiers.py
+++ b/tests/template_engine/test_parser_identifiers.py
@@ -1,0 +1,130 @@
+"""Unit tests for template parsers - identifiers."""
+
+import pytest
+from pydantic import BaseModel
+
+from hyperextract.utils.template_engine.parsers import parse_identifiers
+from hyperextract.utils.template_engine.parsers.schemas import (
+    GraphIdentifiersSchema,
+)
+
+
+class Entity(BaseModel):
+    name: str
+
+
+class Relation(BaseModel):
+    source: str
+    target: str
+    type: str
+
+
+class CustomRelation(BaseModel):
+    """Relation whose endpoint fields are not named source/target."""
+
+    subject: str
+    object: str
+    type: str
+
+
+class NumericRelation(BaseModel):
+    source: int
+    target: int
+    type: str
+
+
+class HyperRelation(BaseModel):
+    name: str
+    participants: list[str]
+
+
+class NestedHyperRelation(BaseModel):
+    name: str
+    group_a: list[str]
+    group_b: list[str]
+
+
+def _graph_members_extractor(relation_members):
+    """Build the members extractor via the public parse_identifiers API."""
+    identifiers = GraphIdentifiersSchema(
+        entity_id="name",
+        relation_id="{type}",
+        relation_members=relation_members,
+    )
+    _, _, members_extractor = parse_identifiers(identifiers, "graph")
+    return members_extractor
+
+
+class TestGraphRelationMembers:
+    """Dict-based relation_members for binary graph types."""
+
+    def test_default_source_target_mapping(self):
+        """Standard {source: source, target: target} mapping works."""
+        extractor = _graph_members_extractor({"source": "source", "target": "target"})
+        edge = Relation(source="A", target="B", type="knows")
+
+        assert extractor(edge) == ("A", "B")
+
+    def test_direction_is_preserved(self):
+        """Directed edges must keep (source, target) order, not sorted order."""
+        extractor = _graph_members_extractor({"source": "source", "target": "target"})
+        edge = Relation(source="B", target="A", type="manages")
+
+        assert extractor(edge) == ("B", "A")
+
+    def test_custom_field_mapping(self):
+        """Dict values map to custom edge field names, per documented contract."""
+        extractor = _graph_members_extractor({"source": "subject", "target": "object"})
+        edge = CustomRelation(subject="Alice", object="Bob", type="mentors")
+
+        assert extractor(edge) == ("Alice", "Bob")
+
+    def test_custom_field_mapping_preserves_direction(self):
+        """Custom-mapped endpoints also keep source -> target order."""
+        extractor = _graph_members_extractor({"source": "subject", "target": "object"})
+        edge = CustomRelation(subject="Zoe", object="Adam", type="mentors")
+
+        assert extractor(edge) == ("Zoe", "Adam")
+
+    def test_missing_mapped_field_raises(self):
+        """Mapping to a field absent from the edge schema raises AttributeError."""
+        extractor = _graph_members_extractor({"source": "src", "target": "dst"})
+        edge = Relation(source="A", target="B", type="knows")
+
+        with pytest.raises(AttributeError, match="src"):
+            extractor(edge)
+
+    def test_non_string_values_coerced_to_str(self):
+        """Endpoint values are coerced to strings for key comparison."""
+        extractor = _graph_members_extractor({"source": "source", "target": "target"})
+        edge = NumericRelation(source=2, target=1, type="links")
+
+        assert extractor(edge) == ("2", "1")
+
+
+class TestHypergraphRelationMembers:
+    """String and list relation_members for hypergraph types."""
+
+    def test_string_members_returns_sorted_participants(self):
+        """Unordered hyperedge participants are sorted for a stable key."""
+        identifiers = GraphIdentifiersSchema(
+            entity_id="name",
+            relation_id="{name}",
+            relation_members="participants",
+        )
+        _, _, extractor = parse_identifiers(identifiers, "hypergraph")
+        edge = HyperRelation(name="meeting", participants=["Carol", "Alice", "Bob"])
+
+        assert extractor(edge) == ("Alice", "Bob", "Carol")
+
+    def test_list_members_returns_sorted_groups(self):
+        """Nested hyperedge groups are each sorted for a stable key."""
+        identifiers = GraphIdentifiersSchema(
+            entity_id="name",
+            relation_id="{name}",
+            relation_members=["group_a", "group_b"],
+        )
+        _, _, extractor = parse_identifiers(identifiers, "hypergraph")
+        edge = NestedHyperRelation(name="match", group_a=["Y", "X"], group_b=["B", "A"])
+
+        assert extractor(edge) == (("X", "Y"), ("A", "B"))


### PR DESCRIPTION
## Problem

The dict form of `identifiers.relation_members` in graph templates is documented (in the extractor docstring and DESIGN_GUIDE) as mapping to custom edge fields:

```yaml
relation_members:
  source: subject
  target: object
```

But two things go wrong in `_members_extractor()`:

1. The dict values are ignored — the extractor hardcodes `item.source` / `item.target`, so any template whose relation schema uses custom endpoint field names crashes with `AttributeError` during dangling-edge validation.
2. The pair is wrapped in `sorted(...)`, so a directed edge `B -> A` is reported as `("A", "B")`. This silently flips edge direction wherever the extractor is consumed: dangling-edge cleanup, OntoSight `show()`, and Obsidian export.

Built-in presets all use literal `source`/`target` names, which is why the mapping half never surfaced.

## Root cause

`hyperextract/utils/template_engine/parsers/identifiers.py` — the dict branch of `_members_extractor()` doesn't read `members["source"]` / `members["target"]`, and applies `sorted()` to endpoints that are ordered by definition. The function's own docstring documents the intended behavior: `{source: 's', target: 't'} -> lambda x: (x.s, x.t)`.

## Fix

- Read the mapped field names from the dict and access them via `getattr`.
- Preserve `(source, target)` order for binary graph edges. Hypergraph members (string / list forms) are unchanged and stay sorted, since participants there are unordered.
- Raise `AttributeError` listing the missing fields, consistent with `_extractor()`.
- Clarify the dict contract in `DESIGN_GUIDE.md` / `DESIGN_GUIDE_zh.md`.

## Tests

New `tests/template_engine/test_parser_identifiers.py` — 8 pure unit tests through the public `parse_identifiers()` API, no LLM/API key needed:

- default `source`/`target` mapping
- direction preserved for directed edges *(failed before the fix)*
- custom field mapping, with and without reversed values *(failed before the fix)*
- missing mapped field raises `AttributeError`
- non-string endpoint values coerced to `str`
- hypergraph string/list members still sorted (regression guard, unchanged behavior)

Local validation: `uv run pytest` — 327 passed, 10 skipped; `ruff check hyperextract` and `ruff format --check hyperextract` both clean.

## Compatibility

- Edge dedup keys are unaffected — dedup uses the separate `relation_id` / `edge_key_extractor`.
- For built-in presets the only observable change is that edge endpoints are now reported in `(source, target)` order instead of alphabetical order, which matches the documented contract and the `AutoGraph` docstring example (`nodes_in_edge_extractor=lambda x: (x.source, x.target)`).
- No public API changes, no new dependencies, no paid API required for tests.

Made with [Cursor](https://cursor.com)