### PR TITLE
docs: align structured output wording with function_calling implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ llm, emb = create_client(
 
 ## 🚀 Supported Platforms & Models
 
-Hyper-Extract relies on the LLM's structured output capability (`json_schema` or Function Calling).
+Hyper-Extract uses LangChain structured output with **function calling**. The model must support tool/function calling.
 
 | Platform | Verified Models |
 |----------|-----------------|

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -126,7 +126,7 @@ llm, emb = create_client(
 
 ## 🚀 支持的平台与模型
 
-Hyper-Extract 依赖大语言模型的结构化输出能力（`json_schema` 或 Function Calling）。
+Hyper-Extract 通过 LangChain 结构化输出的 **function calling** 方法工作。模型需支持 tool/function calling。
 
 | 平台 | 已验证模型 |
 |----------|-----------------|

--- a/docs/en/concepts/provider-system.md
+++ b/docs/en/concepts/provider-system.md
@@ -8,15 +8,15 @@ Hyper-Extract supports these ways to connect to LLMs: **OpenAI**, **Anthropic**,
 
 ### Cloud API
 
-| Platform | Model | `json_schema` Support | Compatible | Notes |
-|----------|-------|:---------------------:|:----------:|-------|
+| Platform | Model | Function calling | Compatible | Notes |
+|----------|-------|:----------------:|:----------:|-------|
 | **OpenAI** | gpt-4o / gpt-4o-mini / gpt-5 | ✅ | ✅ | Native support, recommended |
 | **Anthropic** | claude-opus-4-8 / claude-sonnet-4-6 / claude-haiku-4-5 | ✅ (tool calling) | ✅ | LLM only — no embeddings API (pair with an OpenAI-compatible embedder). Needs `hyperextract[anthropic]` |
 | **DeepSeek** | deepseek-v4-flash / deepseek-v4-pro | ✅ | ✅ | OpenAI-compatible. V4 models default to "thinking" mode, which Hyper-Extract auto-disables (`extra_body`) so structured extraction works. LLM only — no embeddings API. Keys: `DEEPSEEK_API_KEY` |
 | **Alibaba Bailian** | qwen-plus / qwen-turbo / qwen3.6-plus / deepseek-r1 | ✅ | ✅ | Works out of the box |
-| **Alibaba Bailian** | qwen-max / deepseek-v3 | ❌ | ❌ | Only `json_object`; `json_schema` not supported |
+| **Alibaba Bailian** | qwen-max / deepseek-v3 | ❌ | ❌ | Only `json_object`; not compatible with function-calling structured output |
 
-> **Bailian users**: Both qwen-max and deepseek-v3 do not support `json_schema`. If you hit `messages must contain the word 'json'` or get non-JSON output, switch to qwen-plus, qwen-turbo, or deepseek-r1. See [Issue #24](https://github.com/yifanfeng97/Hyper-Extract/issues/24).
+> **Bailian users**: qwen-max and deepseek-v3 only support `json_object` and are not compatible with Hyper-Extract's function-calling structured output. If you hit `messages must contain the word 'json'` or get non-JSON output, switch to qwen-plus, qwen-turbo, or deepseek-r1. See [Issue #24](https://github.com/yifanfeng97/Hyper-Extract/issues/24).
 
 ### Local Deployment
 

--- a/docs/zh/concepts/provider-system.md
+++ b/docs/zh/concepts/provider-system.md
@@ -8,15 +8,15 @@ Hyper-Extract 支持以下接入方式：**OpenAI**、**Anthropic**、**阿里�
 
 ### 云端 API
 
-| 平台 | 模型 | `json_schema` 支持 | 兼容性 | 备注 |
-|------|------|:------------------:|:------:|------|
+| 平台 | 模型 | 函数调用 | 兼容性 | 备注 |
+|------|------|:--------:|:------:|------|
 | **OpenAI** | gpt-4o / gpt-4o-mini / gpt-5 | ✅ | ✅ | 官方原生支持，推荐 |
 | **Anthropic** | claude-opus-4-8 / claude-sonnet-4-6 / claude-haiku-4-5 | ✅（工具调用） | ✅ | 仅 LLM——无嵌入接口（请搭配 OpenAI 兼容嵌入器）。需 `hyperextract[anthropic]` |
 | **DeepSeek** | deepseek-v4-flash / deepseek-v4-pro | ✅ | ✅ | OpenAI 兼容。V4 模型默认开启"thinking"模式，Hyper-Extract 会自动关闭以保证结构化抽取可用。仅 LLM——无嵌入接口。密钥：`DEEPSEEK_API_KEY` |
 | **阿里云百炼** | qwen-plus / qwen-turbo / qwen3.6-plus / deepseek-r1 | ✅ | ✅ | 直接使用，无需修改 |
-| **阿里云百炼** | qwen-max / deepseek-v3 | ❌ | ❌ | 仅支持 `json_object`，不支持 `json_schema` |
+| **阿里云百炼** | qwen-max / deepseek-v3 | ❌ | ❌ | 仅支持 `json_object`，不兼容 function calling 结构化输出 |
 
-> **百炼用户注意**：qwen-max 和 deepseek-v3 均不支持 `json_schema`，若遇到 `messages must contain the word 'json'` 错误或不返回 JSON，请切换到 qwen-plus、qwen-turbo 或 deepseek-r1。详见 [Issue #24](https://github.com/yifanfeng97/Hyper-Extract/issues/24)。
+> **百炼用户注意**：qwen-max 和 deepseek-v3 仅支持 `json_object`，无法用于 Hyper-Extract 的 function calling 结构化输出。若遇到 `messages must contain the word 'json'` 错误或不返回 JSON，请切换到 qwen-plus、qwen-turbo 或 deepseek-r1。详见 [Issue #24](https://github.com/yifanfeng97/Hyper-Extract/issues/24)。
 
 ### 本地部署
 


### PR DESCRIPTION
## Problem

README and the provider-system docs still describe structured extraction as depending on `json_schema` or Function Calling. That wording is out of date: every extraction path hardcodes LangChain `method="function_calling"`, so users are told about a capability the project no longer uses.

## Root cause

The implementation is the source of truth. AutoModel, AutoGraph, and AutoHypergraph all pass `method="function_calling"` into `with_structured_output` (`hyperextract/types/base.py:76-83`, `hyperextract/types/graph.py:314-329`, `hyperextract/types/hypergraph.py:319-334`). `tests/types/test_structured_output_method.py` locks this because some OpenAI-compatible backends reject LangChain's default `json_schema` method ([Issue #24](https://github.com/yifanfeng97/Hyper-Extract/issues/24)). The docs were not updated after that switch, so they drifted.

## Fix

Wording-only alignment in EN/ZH:

- README ×2: state that Hyper-Extract uses LangChain structured output via **function calling**, and that the model must support tool/function calling.
- `docs/*/concepts/provider-system.md`: rename the compatibility-table column from `` `json_schema` Support `` to Function calling / 函数调用. Keep every model row's ✅/❌ facts. Reword the Bailian qwen-max / deepseek-v3 notes so they no longer claim Hyper-Extract depends on `json_schema`, while keeping the `json_object` limitation, the error-message hint, and the Issue #24 citation.

No code, schema, or compatibility-table facts were changed.

## Tests

- `uv run mkdocs build` — succeeds
- `uv run pytest -v` — 319 passed, 10 skipped
- `uvx ruff check hyperextract` / `uvx ruff format --check hyperextract` — pass (docs-only change)

## Compatibility

Docs-only. Runtime behavior, model compatibility rows, and the `function_calling` lock are unchanged. First-time contributor CI may show no checks until a maintainer approves.

Made with [Cursor](https://cursor.com)