### PR TITLE
fix: honor DEEPSEEK_API_KEY in create_llm OpenAI-compatible path

### DIFF
--- a/hyperextract/utils/client.py
+++ b/hyperextract/utils/client.py
@@ -87,10 +87,12 @@ def _env_api_key(provider: str) -> str:
 
     Falls back to OPENAI_API_KEY for OpenAI-compatible providers.
     """
-    for var in PROVIDER_API_KEY_ENV.get(provider, ("OPENAI_API_KEY",)):
+    for var in PROVIDER_API_KEY_ENV.get(provider, ()):
         value = os.environ.get(var, "")
         if value:
             return value
+    if provider not in ANTHROPIC_PROVIDERS:
+        return os.environ.get("OPENAI_API_KEY", "")
     return ""
 
 
@@ -379,7 +381,7 @@ def create_llm(
 
     chat_kwargs: dict[str, Any] = {
         "model": config["model"],
-        "api_key": config["api_key"] or os.environ.get("OPENAI_API_KEY", ""),
+        "api_key": config["api_key"] or _env_api_key(provider),
         "base_url": config.get("base_url") or None,
         "temperature": config.get("temperature", 0),
     }
@@ -421,10 +423,12 @@ def create_embedder(
     base_url = config.get("base_url", "")
     uses_custom = bool(base_url and base_url.rstrip("/") != OPENAI_API_URL)
 
+    resolved_key = config["api_key"] or _env_api_key(config.get("provider", ""))
+
     if uses_custom:
         return CompatibleEmbeddings(
             model=config["model"],
-            api_key=config["api_key"] or os.environ.get("OPENAI_API_KEY", ""),
+            api_key=resolved_key,
             base_url=base_url,
             **kwargs,
         )
@@ -433,7 +437,7 @@ def create_embedder(
 
         return OpenAIEmbeddings(
             model=config["model"],
-            api_key=config["api_key"] or os.environ.get("OPENAI_API_KEY", ""),
+            api_key=resolved_key,
             **kwargs,
         )
 

--- a/tests/utils/test_client.py
+++ b/tests/utils/test_client.py
@@ -116,6 +116,42 @@ class TestCreateLLM:
         )
         assert llm.extra_body == {"thinking": {"type": "enabled"}}
 
+    def test_create_llm_deepseek_reads_provider_env_key(self, monkeypatch):
+        """create_llm('deepseek') uses DEEPSEEK_API_KEY when api_key is omitted."""
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-deepseek-test")
+        llm = create_llm("deepseek")
+        assert llm.openai_api_key.get_secret_value() == "sk-deepseek-test"
+
+    def test_create_llm_deepseek_prefers_provider_env_over_openai(self, monkeypatch):
+        """DeepSeek prefers DEEPSEEK_API_KEY when both provider and OpenAI keys are set."""
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-deepseek-test")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-test")
+        llm = create_llm("deepseek")
+        assert llm.openai_api_key.get_secret_value() == "sk-deepseek-test"
+
+    def test_create_llm_openai_still_uses_openai_env_key(self, monkeypatch):
+        """OpenAI shorthand still resolves OPENAI_API_KEY (regression)."""
+        monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-test")
+        llm = create_llm("openai:gpt-4o-mini")
+        assert llm.model_name == "gpt-4o-mini"
+        assert llm.openai_api_key.get_secret_value() == "sk-openai-test"
+
+    def test_create_llm_explicit_api_key_wins(self, monkeypatch):
+        """Explicit api_key= takes priority over provider and OpenAI env vars."""
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-deepseek-test")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-test")
+        llm = create_llm("deepseek", api_key="sk-explicit")
+        assert llm.openai_api_key.get_secret_value() == "sk-explicit"
+
+    def test_create_llm_deepseek_falls_back_to_openai_env_key(self, monkeypatch):
+        """DeepSeek still falls back to OPENAI_API_KEY when DEEPSEEK_API_KEY is unset."""
+        monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-test")
+        llm = create_llm("deepseek")
+        assert llm.openai_api_key.get_secret_value() == "sk-openai-test"
+
     def test_create_llm_custom_model(self):
         """Override model via string shorthand."""
         llm = create_llm("bailian:qwen-plus", api_key="sk-test")
@@ -155,6 +191,26 @@ class TestCreateEmbedder:
         )
         assert isinstance(emb, CompatibleEmbeddings)
         assert emb._model == "bge-m3"
+
+    def test_create_embedder_reads_openai_env_key(self, monkeypatch):
+        """create_embedder uses _env_api_key so OPENAI_API_KEY is picked up."""
+        monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-emb")
+        emb = create_embedder("openai")
+        assert emb.openai_api_key.get_secret_value() == "sk-openai-emb"
+
+    def test_create_embedder_explicit_api_key_wins(self, monkeypatch):
+        """Explicit api_key= still wins for embedders (regression)."""
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-emb")
+        emb = create_embedder("openai", api_key="sk-explicit-emb")
+        assert emb.openai_api_key.get_secret_value() == "sk-explicit-emb"
+
+    def test_create_embedder_custom_url_reads_openai_env_key(self, monkeypatch):
+        """CompatibleEmbeddings path also resolves the env key via the factory."""
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-emb")
+        emb = create_embedder("bailian")
+        assert isinstance(emb, CompatibleEmbeddings)
+        assert emb._client.api_key == "sk-openai-emb"
 
 
 # =============================================================================


### PR DESCRIPTION
## Problem

`create_llm("deepseek")` / `create_client(llm="deepseek")` ignore `DEEPSEEK_API_KEY` when `api_key=` is omitted. The constructed `ChatOpenAI` gets an empty key and the first request fails authentication.

`PROVIDER_API_KEY_ENV` already maps DeepSeek, and the Anthropic branch of `create_llm()` already calls `_env_api_key()`. The OpenAI-compatible branch (DeepSeek, Bailian, vLLM, …) hardcoded `os.environ.get("OPENAI_API_KEY")` instead, so the two factory paths disagreed with `ConfigManager` / `get_client()`.

Fixes #76. Related: #52, #67.

## Root cause

In `hyperextract/utils/client.py`, `create_llm()`'s OpenAI-compatible path (and both `create_embedder()` constructors) resolved the key with:

```python
config["api_key"] or os.environ.get("OPENAI_API_KEY", "")
```

That bypasses `_env_api_key()` entirely. `_parse_client_spec()` only copies an explicit `api_key=` into `config["api_key"]`; an empty string then falls through to the hardcoded OpenAI env var.

`_env_api_key()`'s docstring also claimed an `OPENAI_API_KEY` fallback for OpenAI-compatible providers, but the helper returned immediately after the provider-specific vars, so mapped providers such as DeepSeek never reached that fallback.

## Fix

- OpenAI-compatible `create_llm()` now uses `config["api_key"] or _env_api_key(provider)`, matching the Anthropic branch.
- `create_embedder()` uses the same helper (DeepSeek has no embeddings API; this is the same bug on the embedder constructors).
- `_env_api_key()` now actually falls back to `OPENAI_API_KEY` for non-Anthropic providers, matching its docstring. Explicit `api_key=` is unchanged: `_parse_client_spec()` still stores it on `config["api_key"]`, which is checked first.

## Tests

Pure unit tests in `tests/utils/test_client.py` via `monkeypatch` — no network, no real keys:

- `create_llm("deepseek")` with only `DEEPSEEK_API_KEY` *(failed before the fix)*
- both env vars set → DeepSeek prefers `DEEPSEEK_API_KEY` *(failed before the fix)*
- `create_llm("openai:gpt-4o-mini")` still uses `OPENAI_API_KEY`
- explicit `api_key=` still wins over env vars
- DeepSeek still falls back to `OPENAI_API_KEY` when `DEEPSEEK_API_KEY` is unset
- `create_embedder()` env-key + explicit-key coverage on both OpenAI and custom-URL paths

Local validation: `uv run pytest` — 327 passed, 10 skipped; `ruff check hyperextract` and `ruff format --check hyperextract` both clean.

## Compatibility

- No public API changes. Callers that already pass `api_key=` are unaffected.
- Users who currently point `create_llm("deepseek")` at `OPENAI_API_KEY` only still work, via the helper fallback.
- `ConfigManager` / `cli/config.py` are untouched.
- Overlaps the `_env_api_key` call-site change in #71 (OrcaRouter provider). This PR is the focused env-key fix plus tests; it does not add providers.

No paid API needed for tests; no public API changes.

Made with [Cursor](https://cursor.com)