### PR TITLE
docs: fix dev environment install commands (.[dev] extra does not exist)

### DIFF
--- a/docs/en/getting-started/installation.md
+++ b/docs/en/getting-started/installation.md
@@ -81,11 +81,11 @@ If you want to contribute or modify the source code:
 git clone https://github.com/yifanfeng97/hyper-extract.git
 cd hyper-extract
 
-# Install with uv (recommended)
-uv sync --extra dev
+# Install with uv (recommended) — includes the `dev` dependency group
+uv sync
 
-# Or with pip
-pip install -e ".[dev]"
+# Or with pip (pip 25.1+)
+pip install -e . --group dev
 ```
 
 ---

--- a/docs/en/python/index.md
+++ b/docs/en/python/index.md
@@ -10,10 +10,12 @@ Build knowledge extraction pipelines with the Hyper-Extract Python API.
 pip install hyperextract
 ```
 
-For development:
+For development, clone the repository and install the `dev` dependency group:
 
 ```bash
-pip install hyperextract[dev]
+git clone https://github.com/yifanfeng97/hyper-extract.git
+cd hyper-extract
+uv sync
 ```
 
 ---

--- a/docs/en/resources/contributing.md
+++ b/docs/en/resources/contributing.md
@@ -26,12 +26,13 @@ cd hyper-extract
 ### 2. Set Up Development Environment
 
 ```bash
-# Create virtual environment
+# Recommended: uv (installs the `dev` dependency group by default)
+uv sync
+
+# Or with pip (pip 25.1+)
 python -m venv venv
 source venv/bin/activate  # Windows: venv\Scripts\activate
-
-# Install in editable mode
-pip install -e ".[dev]"
+pip install -e . --group dev
 ```
 
 ### 3. Run Tests

--- a/docs/zh/getting-started/installation.md
+++ b/docs/zh/getting-started/installation.md
@@ -81,11 +81,11 @@ Hyper-Extract 需要 **Python 3.11+**。
 git clone https://github.com/yifanfeng97/hyper-extract.git
 cd hyper-extract
 
-# 使用 uv 安装（推荐）
-uv sync --extra dev
+# 使用 uv 安装（推荐）——会安装 `dev` 依赖组
+uv sync
 
-# 或使用 pip
-pip install -e ".[dev]"
+# 或使用 pip（pip 25.1+）
+pip install -e . --group dev
 ```
 
 ---

--- a/docs/zh/python/index.md
+++ b/docs/zh/python/index.md
@@ -10,10 +10,12 @@
 pip install hyperextract
 ```
 
-开发安装：
+开发安装请克隆仓库并安装 `dev` 依赖组：
 
 ```bash
-pip install hyperextract[dev]
+git clone https://github.com/yifanfeng97/hyper-extract.git
+cd hyper-extract
+uv sync
 ```
 
 ---

--- a/docs/zh/resources/contributing.md
+++ b/docs/zh/resources/contributing.md
@@ -26,12 +26,13 @@ cd hyper-extract
 ### 2. 配置开发环境
 
 ```bash
-# 创建虚拟环境
+# 推荐：uv（默认安装 `dev` 依赖组）
+uv sync
+
+# 或使用 pip（pip 25.1+）
 python -m venv venv
 source venv/bin/activate  # Windows: venv\Scripts\activate
-
-# 以可编辑模式安装
-pip install -e ".[dev]"
+pip install -e . --group dev
 ```
 
 ### 3. 运行测试


### PR DESCRIPTION
## Problem

The development-install commands in the docs reference a `dev` extra that does not exist. New contributors following those snippets cannot install pytest, mkdocs, or the rest of the local toolchain as documented.

Broken commands (EN/ZH):

- `uv sync --extra dev` in `docs/*/getting-started/installation.md`
- `pip install -e ".[dev]"` in `docs/*/getting-started/installation.md` and `docs/*/resources/contributing.md`
- `pip install hyperextract[dev]` in `docs/*/python/index.md`

## Root cause

[`pyproject.toml`](https://github.com/yifanfeng97/Hyper-Extract/blob/ecba6c5/pyproject.toml) puts pytest/mkdocs under `[dependency-groups].dev` (PEP 735). `[project.optional-dependencies]` only defines `anthropic`, `google`, `mcp`, and `all` — there is no `dev` extra.

So:

- `uv sync --extra dev` looks up an extra named `dev` and fails
- `pip install -e ".[dev]"` / `pip install hyperextract[dev]` do not install the `dev` group (newer pip warns and continues with runtime deps only)

`uv sync` already installs the default `dev` group. pip 25.1+ needs `--group dev` for the same set.

## Fix

EN/ZH kept in sync. Commands now match the actual layout:

- **uv (recommended):** `uv sync`
- **pip (25.1+):** `pip install -e . --group dev`

`docs/*/python/index.md` now points at a source checkout + `uv sync` instead of a non-existent PyPI extra.

## Tests

Reproduced the broken commands, then verified the replacements:

```text
$ uv sync --extra dev
error: Extra `dev` is not defined in the `optional-dependencies` table for `hyperextract`

$ pip install -e ".[dev]"   # pip 26.2.1
WARNING: hyperextract 0.4.0 does not provide the extra 'dev'
# installs runtime deps only (no mkdocs from the `dev` group)

$ uv sync
# success; pytest 9.0.2 and mkdocs 1.6.1 present

$ pip install -e . --group dev   # pip 26.2.1, Python 3.11
# success; mkdocs 1.6.1 and the rest of the `dev` group installed
```

Acceptance:

```text
uv run mkdocs build          # Documentation built (exit 0)
uvx ruff check hyperextract  # All checks passed
uvx ruff format --check hyperextract  # 59 files already formatted
uv run pytest                # 319 passed, 10 skipped (after `uv sync --all-extras`)
```

Note: `uv sync` without extras is enough for docs/contrib tooling. Anthropic tests need the `anthropic` extra (`langchain_anthropic`); CI already installs `.[all]`.

## Compatibility

Docs-only. Runtime extras (`anthropic`, `google`, `mcp`, `all`) are unchanged. `pip install -e . --group dev` requires pip 25.1+; uv users should use `uv sync`.

Made with [Cursor](https://cursor.com)