### PR TITLE
fix: support MCP Python SDK 2.x in build_server

### DIFF
--- a/hyperextract/mcp_server.py
+++ b/hyperextract/mcp_server.py
@@ -231,10 +231,15 @@ def _model_to_dict(item: Any) -> Any:
 
 
 def build_server():
-    """Build the FastMCP server with all tools registered."""
-    from mcp.server.fastmcp import FastMCP
+    """Build the MCP server with all tools registered."""
+    try:  # mcp 1.x
+        from mcp.server.fastmcp import FastMCP
 
-    server = FastMCP(SERVER_NAME)
+        server = FastMCP(SERVER_NAME)
+    except ImportError:  # mcp 2.x: FastMCP was renamed to MCPServer
+        from mcp.server.mcpserver import MCPServer
+
+        server = MCPServer(SERVER_NAME)
     for fn in (list_templates, info, search, ask, export_obsidian):
         server.tool()(fn)
     return server


### PR DESCRIPTION
## Summary

Unblocks #72 and dependabot PR #68. mcp 2.x renamed `FastMCP` to `MCPServer` and deleted `mcp.server.fastmcp` with no deprecation shim, so `he-mcp` / `build_server()` die on import the moment `mcp>=2` resolves. #68 (pin relaxation to `<3`) must not merge before this lands.

## Change

`build_server()` in `hyperextract/mcp_server.py` now tries the 1.x import first and falls back to the 2.x import:

```python
try:  # mcp 1.x
    from mcp.server.fastmcp import FastMCP
    server = FastMCP(SERVER_NAME)
except ImportError:  # mcp 2.x: FastMCP was renamed to MCPServer
    from mcp.server.mcpserver import MCPServer
    server = MCPServer(SERVER_NAME)
```

No tool-surface, transport, or protocol changes. Same server name, same five tools (`list_templates` / `info` / `search` / `ask` / `export_obsidian`), same stdio default.

## Verification

Probed in an isolated venv (Python 3.11):

| mcp version | before this PR | after this PR |
|---|---|---|
| 1.29.1 (current pin) | 8 passed | 8 passed |
| 2.1.1 (`mcp>=2,<3`) | `ModuleNotFoundError: No module named 'mcp.server.fastmcp'` | **8 passed** |

Also confirmed against the [official migration guide](https://py.sdk.modelcontextprotocol.io/v2/migration/#fastmcp-renamed-to-mcpserver): tool registration (`server.tool()(fn)`), docstring→description passthrough, parameter schemas, and `run()` stdio default are all unchanged between 1.x and 2.x for the surface this server uses.

## After merging

1. `hyperextract[mcp]` pin can be relaxed to `mcp>=1.2.0,<3` (supersedes/reenables #68)
2. Closes #72

Refs: #72, #68