### PR TITLE
feat: add `he template validate` with machine-readable diagnostics

### DIFF
--- a/docs/en/cli/commands/list.md
+++ b/docs/en/cli/commands/list.md
@@ -145,5 +145,6 @@ he list method | grep -q light_rag && echo "Available"
 ## See Also
 
 - [`he parse`](parse.md) — Use templates/methods
+- [`he template validate`](template.md) — Check a template YAML file
 - [Template Library](../../templates/index.md) — Detailed template documentation
 - [Choosing Methods](../../concepts/methods.md) — Method selection guide

--- a/docs/en/cli/commands/template.md
+++ b/docs/en/cli/commands/template.md
@@ -1,0 +1,120 @@
+# he template validate
+
+Check a Hyper-Extract YAML template for structural and semantic problems before you run extraction.
+
+`load_template()` only verifies that the document matches the Pydantic `TemplateCfg` shape. Identifier fields that do not exist, display placeholders that do not match the schema, and missing time/location fields on temporal or spatial types otherwise fail later, during extraction. This command runs those checks up front.
+
+`template` is a command group; `validate` is the subcommand.
+
+---
+
+## Synopsis
+
+```bash
+he template validate PATH [--json] [--all]
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `PATH` | Template YAML file, or a directory when `--all` is set |
+
+## Options
+
+| Option | Alias | Default | Description |
+|--------|-------|---------|-------------|
+| `--json` | | off | Print machine-readable JSON instead of Rich text |
+| `--all` | | off | Validate every `*.yaml` / `*.yml` file under a directory |
+
+---
+
+## Description
+
+The validator is a sidecar for template authors. It does **not** change runtime `load_template()` behavior.
+
+Checks follow `hyperextract-skills/yaml-validator/` and `templates/DESIGN_GUIDE.md`:
+
+| Code | Check | Severity |
+|------|--------|----------|
+| `HE-T001` | YAML is parseable | error |
+| `HE-T002` | Document matches `TemplateCfg` | error |
+| `HE-T003` | Identifier fields (`entity_id`, `relation_id`, `relation_members`, `item_id`, `time_field`, `location_field`) exist on the relevant output schema | error |
+| `HE-T004` | `relation_members` type matches AutoType (`graph` / temporal / spatial → dict; `hypergraph` → string or list). Dict **values** are edge-schema field names. Hypergraph member fields must be `type: list`. | error |
+| `HE-T005` | Display `{field}` placeholders exist on the corresponding schema | error |
+| `HE-T006` | Temporal types define `time_field`; spatial types define `location_field` | error |
+| `HE-T007` | Declared languages are present on bilingual dict fields | warning |
+| `HE-T008` | Entity or relation field count exceeds the DESIGN_GUIDE limit of 5 | warning |
+| `HE-T009` | `domain/name` collides with a Gallery preset | warning |
+
+Exit code **1** if any **error** is reported; **0** if the template is clean or has warnings only.
+
+---
+
+## Examples
+
+### Validate one file
+
+```bash
+he template validate ./my_template.yaml
+```
+
+### Machine-readable diagnostics
+
+```bash
+he template validate ./my_template.yaml --json
+```
+
+```json
+{
+  "file": "./my_template.yaml",
+  "diagnostics": [
+    {
+      "code": "HE-T003",
+      "severity": "error",
+      "path": "identifiers.entity_id",
+      "message": "Field 'nickname' is not defined in output.entities"
+    }
+  ],
+  "ok": false
+}
+```
+
+### Validate every bundled preset
+
+```bash
+he template validate hyperextract/templates/presets --all
+```
+
+Directory mode with `--json` wraps each file:
+
+```json
+{
+  "results": [
+    {"file": "…/base_graph.yaml", "diagnostics": [], "ok": true}
+  ],
+  "ok": true
+}
+```
+
+---
+
+## Python API
+
+The CLI is a thin wrapper around the same checks:
+
+```python
+from hyperextract.utils.template_engine import validate_template
+
+result = validate_template("my_template.yaml")
+print(result.ok, result.to_dict())
+```
+
+---
+
+## See Also
+
+- [`he list template`](list.md) — Browse bundled templates
+- [`he parse`](parse.md) — Extract with a template
+- [Creating Custom Templates](../../python/guides/custom-templates.md)
+- [Template Library](../../templates/index.md)

--- a/docs/en/cli/index.md
+++ b/docs/en/cli/index.md
@@ -40,6 +40,7 @@ he --version
 | `he build-index` | Build/rebuild search index | `-f` force rebuild |
 | `he clean` | Remove a KA's index (or the whole KA) | `-a` all, `-y` yes |
 | `he list` | List templates and methods | `template` or `method` |
+| `he template validate` | Validate a template YAML file | `--json`, `--all` |
 | `he config` | Manage configuration | `init`, `show`, `llm`, `embedder` |
 
 ---
@@ -173,6 +174,7 @@ he show ./output/
 - **[`he build-index`](commands/build-index.md)** — Build search index
 - **[`he clean`](commands/clean.md)** — Remove a KA's index, or the whole KA
 - **[`he list`](commands/list.md)** — List available templates/methods
+- **[`he template validate`](commands/template.md)** — Validate a template YAML file
 - **[`he config`](commands/config.md)** — Configuration management
 
 ---

--- a/docs/en/python/guides/custom-templates.md
+++ b/docs/en/python/guides/custom-templates.md
@@ -105,6 +105,10 @@ display:
 
 ### 3. Validate and Use
 
+```bash
+he template validate ~/.hyperextract/templates/my_domain/my_template.yaml
+```
+
 ```python
 from hyperextract import Template
 
@@ -114,6 +118,8 @@ ka = Template.create("my_domain/my_template", "en")
 # Use it
 result = ka.parse("Your document text here")
 ```
+
+See [`he template validate`](../../cli/commands/template.md) for the diagnostic codes and JSON output.
 
 ---
 

--- a/docs/zh/cli/commands/list.md
+++ b/docs/zh/cli/commands/list.md
@@ -145,5 +145,6 @@ he list method | grep -q light_rag && echo "Available"
 ## 另请参见
 
 - [`he parse`](parse.md) — 使用模板/方法
+- [`he template validate`](template.md) — 校验模板 YAML 文件
 - [模板库](../../templates/index.md) — 详细模板文档
 - [选择方法](../../concepts/methods.md) — 方法选择指南

--- a/docs/zh/cli/commands/template.md
+++ b/docs/zh/cli/commands/template.md
@@ -1,0 +1,120 @@
+# he template validate
+
+在运行抽取之前，检查 Hyper-Extract YAML 模板的结构和语义问题。
+
+`load_template()` 只验证文档是否符合 Pydantic `TemplateCfg` 形状。标识符引用了不存在的字段、display 占位符与 schema 不匹配、时序/空间类型缺少 time/location 字段时，错误会拖到抽取阶段才出现。本命令把这些检查提前到编写模板时。
+
+`template` 是命令组，`validate` 是子命令。
+
+---
+
+## 用法
+
+```bash
+he template validate PATH [--json] [--all]
+```
+
+## 参数
+
+| 参数 | 说明 |
+|----------|-------------|
+| `PATH` | 模板 YAML 文件；使用 `--all` 时可以是目录 |
+
+## 选项
+
+| 选项 | 别名 | 默认值 | 说明 |
+|--------|-------|---------|-------------|
+| `--json` | | 关闭 | 输出机器可读 JSON，而不是 Rich 文本 |
+| `--all` | | 关闭 | 校验目录下每一个 `*.yaml` / `*.yml` 文件 |
+
+---
+
+## 说明
+
+校验器是给模板作者用的旁路工具，**不会**改变运行时 `load_template()` 的行为。
+
+检查项来自 `hyperextract-skills/yaml-validator/` 与 `templates/DESIGN_GUIDE.md`：
+
+| 编码 | 检查 | 严重级别 |
+|------|--------|----------|
+| `HE-T001` | YAML 可解析 | error |
+| `HE-T002` | 文档符合 `TemplateCfg` | error |
+| `HE-T003` | 标识符字段（`entity_id`、`relation_id`、`relation_members`、`item_id`、`time_field`、`location_field`）在对应 output schema 中存在 | error |
+| `HE-T004` | `relation_members` 类型与 AutoType 匹配（`graph` / 时序 / 空间 → dict；`hypergraph` → 字符串或列表）。dict 的**值**是边 schema 的字段名。超图成员字段必须为 `type: list`。 | error |
+| `HE-T005` | display 中的 `{field}` 占位符在对应 schema 中存在 | error |
+| `HE-T006` | 时序类型定义 `time_field`；空间类型定义 `location_field` | error |
+| `HE-T007` | 已声明的语言在双语字典字段中齐全 | warning |
+| `HE-T008` | 实体或关系字段数超过 DESIGN_GUIDE 上限 5 | warning |
+| `HE-T009` | `domain/name` 与 Gallery 中已有 preset 冲突 | warning |
+
+存在任何 **error** 时退出码为 **1**；全部通过或仅有 warning 时为 **0**。
+
+---
+
+## 示例
+
+### 校验单个文件
+
+```bash
+he template validate ./my_template.yaml
+```
+
+### 机器可读诊断
+
+```bash
+he template validate ./my_template.yaml --json
+```
+
+```json
+{
+  "file": "./my_template.yaml",
+  "diagnostics": [
+    {
+      "code": "HE-T003",
+      "severity": "error",
+      "path": "identifiers.entity_id",
+      "message": "Field 'nickname' is not defined in output.entities"
+    }
+  ],
+  "ok": false
+}
+```
+
+### 校验全部内置 preset
+
+```bash
+he template validate hyperextract/templates/presets --all
+```
+
+目录模式配合 `--json` 时，每个文件包在 `results` 里：
+
+```json
+{
+  "results": [
+    {"file": "…/base_graph.yaml", "diagnostics": [], "ok": true}
+  ],
+  "ok": true
+}
+```
+
+---
+
+## Python API
+
+CLI 是同一套检查的薄封装：
+
+```python
+from hyperextract.utils.template_engine import validate_template
+
+result = validate_template("my_template.yaml")
+print(result.ok, result.to_dict())
+```
+
+---
+
+## 另请参见
+
+- [`he list template`](list.md) — 浏览内置模板
+- [`he parse`](parse.md) — 使用模板抽取
+- [创建自定义模板](../../python/guides/custom-templates.md)
+- [模板库](../../templates/index.md)

--- a/docs/zh/cli/index.md
+++ b/docs/zh/cli/index.md
@@ -40,6 +40,7 @@ he --version
 | `he build-index` | 构建/重建搜索索引 | `-f` 强制重建 |
 | `he clean` | 删除 KA 的索引（或整个 KA） | `-a` all, `-y` yes |
 | `he list` | 列出模板和方法 | `template` 或 `method` |
+| `he template validate` | 校验模板 YAML | `--json`、`--all` |
 | `he config` | 管理配置 | `init`, `show`, `llm`, `embedder` |
 
 ---
@@ -173,6 +174,7 @@ he show ./output/
 - **[`he build-index`](commands/build-index.md)** — 构建搜索索引
 - **[`he clean`](commands/clean.md)** — 删除 KA 的索引，或整个 KA
 - **[`he list`](commands/list.md)** — 列出可用模板/方法
+- **[`he template validate`](commands/template.md)** — 校验模板 YAML 文件
 - **[`he config`](commands/config.md)** — 配置管理
 
 ---

--- a/docs/zh/python/guides/custom-templates.md
+++ b/docs/zh/python/guides/custom-templates.md
@@ -105,6 +105,10 @@ display:
 
 ### 3. 验证并使用
 
+```bash
+he template validate ~/.hyperextract/templates/my_domain/my_template.yaml
+```
+
 ```python
 from hyperextract import Template
 
@@ -114,6 +118,8 @@ ka = Template.create("my_domain/my_template", "zh")
 # 使用
 result = ka.parse("您的文档文本")
 ```
+
+诊断编码与 JSON 输出见 [`he template validate`](../../cli/commands/template.md)。
 
 ---
 

--- a/hyperextract/cli/cli.py
+++ b/hyperextract/cli/cli.py
@@ -12,7 +12,7 @@ from rich.text import Text
 from hyperextract.utils.logging import configure_logging, get_logger
 from hyperextract.utils.template_engine import Gallery, Template
 
-from .commands import config_app, list_app
+from .commands import config_app, list_app, template_app
 from .config import (
     load_ka_metadata,
 )
@@ -38,6 +38,7 @@ app = typer.Typer(
 
 app.add_typer(list_app, name="list")
 app.add_typer(config_app, name="config")
+app.add_typer(template_app, name="template")
 
 
 @app.callback()
@@ -110,6 +111,7 @@ def main(
                 [
                     ("he list template", "List available templates"),
                     ("he list method", "List extraction methods"),
+                    ("he template validate <yaml>", "Validate a template YAML file"),
                     ("he config --help", "Manage LLM/Embedder config"),
                 ],
             ),

--- a/hyperextract/cli/commands/__init__.py
+++ b/hyperextract/cli/commands/__init__.py
@@ -2,5 +2,6 @@
 
 from .config import app as config_app
 from .list import app as list_app
+from .template import app as template_app
 
-__all__ = ["config_app", "list_app"]
+__all__ = ["config_app", "list_app", "template_app"]

--- a/hyperextract/cli/commands/template.py
+++ b/hyperextract/cli/commands/template.py
@@ -1,0 +1,136 @@
+"""Template authoring commands for Hyper-Extract CLI."""
+
+import json
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from hyperextract.utils.logging import get_logger
+from hyperextract.utils.template_engine import (
+    ValidationResult,
+    validate_template,
+    validate_template_dir,
+)
+from hyperextract.utils.template_engine.validator import iter_template_files
+
+logger = get_logger("he.template")
+console = Console()
+
+app = typer.Typer(
+    name="template",
+    help="Template authoring tools",
+    no_args_is_help=True,
+)
+
+
+def _print_human(result: ValidationResult) -> None:
+    if result.ok and not result.diagnostics:
+        console.print(f"[bold green]OK[/bold green]  {result.file}")
+        return
+    if result.ok:
+        console.print(
+            f"[bold yellow]OK[/bold yellow]  {result.file}  "
+            f"({result.warning_count} warning"
+            f"{'s' if result.warning_count != 1 else ''})"
+        )
+    else:
+        console.print(
+            f"[bold red]FAILED[/bold red]  {result.file}  "
+            f"({result.error_count} error"
+            f"{'s' if result.error_count != 1 else ''}, "
+            f"{result.warning_count} warning"
+            f"{'s' if result.warning_count != 1 else ''})"
+        )
+    for diagnostic in result.diagnostics:
+        color = "red" if diagnostic.severity == "error" else "yellow"
+        location = diagnostic.path or "-"
+        console.print(
+            f"  [{color}]{diagnostic.severity:7}[/{color}] "
+            f"{diagnostic.code}  {location}  {diagnostic.message}"
+        )
+
+
+def _emit_json(payload: dict) -> None:
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+
+
+@app.command("validate")
+def validate(
+    path: str = typer.Argument(
+        ...,
+        help="Template YAML file, or a directory when using --all",
+    ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Print machine-readable JSON diagnostics",
+    ),
+    all_files: bool = typer.Option(
+        False,
+        "--all",
+        help="Validate every YAML file under a directory",
+    ),
+):
+    """Validate a template YAML file (or a directory of templates)."""
+    logger.info(
+        "command=template-validate path=%s json=%s all=%s",
+        path,
+        json_output,
+        all_files,
+    )
+    target = Path(path)
+
+    if not target.exists():
+        result = validate_template(target)
+        if json_output:
+            _emit_json(result.to_dict())
+        else:
+            console.print(f"[red]Error:[/red] {result.diagnostics[0].message}")
+        raise typer.Exit(1)
+
+    if target.is_dir() and not all_files:
+        console.print(
+            "[red]Error:[/red] PATH is a directory. Re-run with --all to validate "
+            "every YAML file under it."
+        )
+        raise typer.Exit(1)
+
+    if target.is_file() and all_files:
+        console.print(
+            "[red]Error:[/red] --all is for directories. Pass a directory path."
+        )
+        raise typer.Exit(1)
+
+    if target.is_dir():
+        files = iter_template_files(target)
+        if not files:
+            console.print(f"[red]Error:[/red] No YAML templates found in {target}")
+            raise typer.Exit(1)
+        results = validate_template_dir(target)
+        ok = all(item.ok for item in results)
+        if json_output:
+            _emit_json(
+                {
+                    "results": [item.to_dict() for item in results],
+                    "ok": ok,
+                }
+            )
+        else:
+            for item in results:
+                _print_human(item)
+            errors = sum(item.error_count for item in results)
+            warnings = sum(item.warning_count for item in results)
+            console.print()
+            console.print(
+                f"[dim]Validated {len(results)} template(s): "
+                f"{errors} error(s), {warnings} warning(s)[/dim]"
+            )
+        raise typer.Exit(0 if ok else 1)
+
+    result = validate_template(target)
+    if json_output:
+        _emit_json(result.to_dict())
+    else:
+        _print_human(result)
+    raise typer.Exit(0 if result.ok else 1)

--- a/hyperextract/utils/template_engine/__init__.py
+++ b/hyperextract/utils/template_engine/__init__.py
@@ -10,6 +10,7 @@ Main Components:
 - SchemaParser: Parses output schemas based on template type
 - GuidelineParser: Parses prompts based on template type
 - parse_identifiers: Parses identifier extractors from config
+- validate_template: Semantic checks with machine-readable diagnostics
 """
 
 from .factory import TemplateFactory
@@ -20,12 +21,22 @@ from .parsers import (
     localize_template,
 )
 from .template import Template
+from .validator import (
+    Diagnostic,
+    ValidationResult,
+    validate_template,
+    validate_template_dir,
+)
 
 __all__ = [
+    "Diagnostic",
     "Gallery",
     "Template",
     "TemplateCfg",
     "TemplateFactory",
+    "ValidationResult",
     "load_template",
     "localize_template",
+    "validate_template",
+    "validate_template_dir",
 ]

--- a/hyperextract/utils/template_engine/validator.py
+++ b/hyperextract/utils/template_engine/validator.py
@@ -1,0 +1,835 @@
+"""Semantic validator for Hyper-Extract YAML templates.
+
+``load_template()`` only checks Pydantic shape. This module applies the checks
+documented in ``hyperextract-skills/yaml-validator/`` so authors can catch
+identifier, display, and spatiotemporal mistakes before extraction.
+
+The runtime loader is intentionally left unchanged.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+from pydantic import ValidationError
+
+from .gallery import Gallery
+from .parsers.loader import TemplateCfg, localize_template
+from .parsers.schemas.base import FieldSchema
+from .parsers.schemas.graph import (
+    GraphDisplaySchema,
+    GraphIdentifiersSchema,
+    GraphOutputSchema,
+)
+from .parsers.schemas.naive import (
+    NaiveDisplaySchema,
+    NaiveIdentifierSchema,
+    NaiveOutputSchema,
+)
+
+Severity = Literal["error", "warning"]
+
+HE_T001 = "HE-T001"  # YAML syntax
+HE_T002 = "HE-T002"  # TemplateCfg / schema
+HE_T003 = "HE-T003"  # identifier field reference
+HE_T004 = "HE-T004"  # relation_members type mismatch
+HE_T005 = "HE-T005"  # display placeholder
+HE_T006 = "HE-T006"  # missing time_field / location_field
+HE_T007 = "HE-T007"  # bilingual completeness
+HE_T008 = "HE-T008"  # field count > DESIGN_GUIDE limit
+HE_T009 = "HE-T009"  # Gallery domain/name collision
+
+GRAPH_TYPES = frozenset(
+    {
+        "graph",
+        "hypergraph",
+        "temporal_graph",
+        "spatial_graph",
+        "spatio_temporal_graph",
+    }
+)
+BINARY_GRAPH_TYPES = frozenset(
+    {"graph", "temporal_graph", "spatial_graph", "spatio_temporal_graph"}
+)
+TEMPORAL_TYPES = frozenset({"temporal_graph", "spatio_temporal_graph"})
+SPATIAL_TYPES = frozenset({"spatial_graph", "spatio_temporal_graph"})
+RECORD_TYPES = frozenset({"model", "list", "set"})
+
+FIELD_COUNT_LIMIT = 5
+_PLACEHOLDER_RE = re.compile(r"\{(\w+)\}")
+_LANG_KEY_RE = re.compile(r"^[a-z]{2}(?:-[A-Za-z]+)?$")
+
+
+@dataclass(frozen=True)
+class Diagnostic:
+    """A single validator finding."""
+
+    code: str
+    severity: Severity
+    path: str
+    message: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "code": self.code,
+            "severity": self.severity,
+            "path": self.path,
+            "message": self.message,
+        }
+
+
+@dataclass
+class ValidationResult:
+    """Outcome of validating one template file."""
+
+    file: str
+    diagnostics: list[Diagnostic] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not any(d.severity == "error" for d in self.diagnostics)
+
+    @property
+    def error_count(self) -> int:
+        return sum(1 for d in self.diagnostics if d.severity == "error")
+
+    @property
+    def warning_count(self) -> int:
+        return sum(1 for d in self.diagnostics if d.severity == "warning")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "file": self.file,
+            "diagnostics": [d.to_dict() for d in self.diagnostics],
+            "ok": self.ok,
+        }
+
+
+def _presets_dir() -> Path:
+    return Path(__file__).resolve().parent.parent.parent / "templates" / "presets"
+
+
+def iter_template_files(path: str | Path) -> list[Path]:
+    """Return YAML template files under ``path`` (file or directory), sorted."""
+    root = Path(path)
+    if root.is_file():
+        return [root]
+    files = [
+        p
+        for p in root.rglob("*")
+        if p.is_file() and p.suffix.lower() in {".yaml", ".yml"}
+    ]
+    return sorted(files)
+
+
+def validate_template_dir(directory: str | Path) -> list[ValidationResult]:
+    """Validate every YAML file under ``directory``."""
+    return [validate_template(p) for p in iter_template_files(directory)]
+
+
+def validate_template(path: str | Path) -> ValidationResult:
+    """Validate one template YAML file.
+
+    Returns a :class:`ValidationResult`. ``ok`` is True when there are no
+    error-severity diagnostics (warnings do not fail the result).
+    """
+    file_path = Path(path)
+    result = ValidationResult(file=str(file_path))
+
+    if not file_path.exists():
+        result.diagnostics.append(
+            Diagnostic(
+                HE_T001,
+                "error",
+                "",
+                f"File not found: {file_path}",
+            )
+        )
+        return result
+
+    raw, load_diags = _load_yaml(file_path)
+    result.diagnostics.extend(load_diags)
+    if raw is None:
+        return result
+
+    config, schema_diags = _parse_config(raw)
+    result.diagnostics.extend(schema_diags)
+    if config is None:
+        return result
+
+    result.diagnostics.extend(_check_localize(config))
+    result.diagnostics.extend(_check_output_shape(config))
+    result.diagnostics.extend(_check_identifiers(config))
+    result.diagnostics.extend(_check_spatiotemporal(config))
+    result.diagnostics.extend(_check_display(config))
+    result.diagnostics.extend(_check_bilingual(config))
+    result.diagnostics.extend(_check_field_count(config))
+    result.diagnostics.extend(_check_gallery_collision(file_path, config))
+    return result
+
+
+def _load_yaml(path: Path) -> tuple[dict[str, Any] | None, list[Diagnostic]]:
+    try:
+        with open(path, encoding="utf-8") as handle:
+            raw = yaml.safe_load(handle)
+    except yaml.YAMLError as exc:
+        loc = ""
+        mark = getattr(exc, "problem_mark", None)
+        if mark is not None:
+            loc = f"line {mark.line + 1}"
+        return None, [
+            Diagnostic(HE_T001, "error", loc, f"YAML is not parseable: {exc}")
+        ]
+    except OSError as exc:
+        return None, [Diagnostic(HE_T001, "error", "", f"Cannot read file: {exc}")]
+
+    if raw is None:
+        return None, [Diagnostic(HE_T002, "error", "", "Template YAML is empty")]
+    if not isinstance(raw, dict):
+        return None, [
+            Diagnostic(
+                HE_T002,
+                "error",
+                "",
+                "Template YAML must be a mapping of keys to values",
+            )
+        ]
+    return raw, []
+
+
+def _parse_config(
+    raw: dict[str, Any],
+) -> tuple[TemplateCfg | None, list[Diagnostic]]:
+    try:
+        return TemplateCfg(**raw), []
+    except ValidationError as exc:
+        diags = []
+        for err in exc.errors():
+            loc = ".".join(str(part) for part in err.get("loc", ()))
+            diags.append(
+                Diagnostic(HE_T002, "error", loc, err.get("msg", "Invalid template"))
+            )
+        if not diags:
+            diags.append(Diagnostic(HE_T002, "error", "", "Invalid template schema"))
+        return None, diags
+    except (TypeError, ValueError) as exc:
+        return None, [Diagnostic(HE_T002, "error", "", str(exc))]
+
+
+def _check_localize(config: TemplateCfg) -> list[Diagnostic]:
+    languages = (
+        config.language if isinstance(config.language, list) else [config.language]
+    )
+    diags: list[Diagnostic] = []
+    for lang in languages:
+        try:
+            localize_template(config, lang)
+        except Exception as exc:
+            diags.append(
+                Diagnostic(
+                    HE_T002,
+                    "error",
+                    "language",
+                    f"Template is not valid for language {lang!r}: {exc}",
+                )
+            )
+    return diags
+
+
+def _check_output_shape(config: TemplateCfg) -> list[Diagnostic]:
+    if config.type in GRAPH_TYPES and not isinstance(config.output, GraphOutputSchema):
+        return [
+            Diagnostic(
+                HE_T002,
+                "error",
+                "output",
+                f"{config.type} templates require output.entities and output.relations",
+            )
+        ]
+    if config.type in RECORD_TYPES and not isinstance(config.output, NaiveOutputSchema):
+        return [
+            Diagnostic(
+                HE_T002,
+                "error",
+                "output",
+                f"{config.type} templates require output.fields",
+            )
+        ]
+    return []
+
+
+def _field_map(schema: NaiveOutputSchema) -> dict[str, FieldSchema]:
+    return {item.name: item for item in schema.fields}
+
+
+def _field_refs(spec: str | None, *, placeholders_only: bool = False) -> list[str]:
+    """Return field names referenced by an identifier or display string.
+
+    Identifiers treat a bare name (``name``) as a field. Display strings only
+    contribute ``{placeholder}`` matches; a constant label with no braces is
+    allowed.
+    """
+    if not spec:
+        return []
+    if "{" in spec:
+        return _PLACEHOLDER_RE.findall(spec)
+    if placeholders_only:
+        return []
+    return [spec]
+
+
+def _missing_fields(
+    spec: str,
+    available: set[str],
+    *,
+    placeholders_only: bool = False,
+) -> list[str]:
+    return [
+        name
+        for name in _field_refs(spec, placeholders_only=placeholders_only)
+        if name not in available
+    ]
+
+
+def _entity_relation_fields(
+    config: TemplateCfg,
+) -> tuple[set[str], set[str]] | None:
+    if not isinstance(config.output, GraphOutputSchema):
+        return None
+    return (
+        set(_field_map(config.output.entities)),
+        set(_field_map(config.output.relations)),
+    )
+
+
+def _record_fields(config: TemplateCfg) -> set[str]:
+    if not isinstance(config.output, NaiveOutputSchema):
+        return set()
+    return set(_field_map(config.output))
+
+
+def _check_identifiers(config: TemplateCfg) -> list[Diagnostic]:
+    if config.type in RECORD_TYPES:
+        return _check_record_identifiers(config)
+    if config.type in GRAPH_TYPES:
+        return _check_graph_identifiers(config)
+    return []
+
+
+def _check_record_identifiers(config: TemplateCfg) -> list[Diagnostic]:
+    if config.type != "set":
+        return []
+
+    diags: list[Diagnostic] = []
+    identifiers = config.identifiers
+    item_id = getattr(identifiers, "item_id", None) if identifiers else None
+    if not item_id:
+        diags.append(
+            Diagnostic(
+                HE_T003,
+                "error",
+                "identifiers.item_id",
+                "set templates require identifiers.item_id",
+            )
+        )
+        return diags
+
+    available = _record_fields(config)
+    missing = _missing_fields(item_id, available)
+    for name in missing:
+        diags.append(
+            Diagnostic(
+                HE_T003,
+                "error",
+                "identifiers.item_id",
+                f"Field {name!r} is not defined in output.fields",
+            )
+        )
+    return diags
+
+
+def _check_graph_identifiers(config: TemplateCfg) -> list[Diagnostic]:
+    diags: list[Diagnostic] = []
+    identifiers = config.identifiers
+    if identifiers is None:
+        diags.append(
+            Diagnostic(
+                HE_T003,
+                "error",
+                "identifiers",
+                f"{config.type} templates require an identifiers section",
+            )
+        )
+        return diags
+
+    if isinstance(identifiers, NaiveIdentifierSchema):
+        diags.append(
+            Diagnostic(
+                HE_T003,
+                "error",
+                "identifiers",
+                f"{config.type} templates require entity_id, relation_id, "
+                "and relation_members (not item_id)",
+            )
+        )
+        return diags
+
+    fields = _entity_relation_fields(config)
+    if fields is None:
+        return diags
+    entity_fields, relation_fields = fields
+
+    entity_id = getattr(identifiers, "entity_id", None)
+    relation_id = getattr(identifiers, "relation_id", None)
+    relation_members = getattr(identifiers, "relation_members", None)
+
+    if not entity_id:
+        diags.append(
+            Diagnostic(
+                HE_T003,
+                "error",
+                "identifiers.entity_id",
+                "entity_id is required for graph templates",
+            )
+        )
+    else:
+        for name in _missing_fields(entity_id, entity_fields):
+            diags.append(
+                Diagnostic(
+                    HE_T003,
+                    "error",
+                    "identifiers.entity_id",
+                    f"Field {name!r} is not defined in output.entities",
+                )
+            )
+
+    if not relation_id:
+        diags.append(
+            Diagnostic(
+                HE_T003,
+                "error",
+                "identifiers.relation_id",
+                "relation_id is required for graph templates",
+            )
+        )
+    else:
+        for name in _missing_fields(relation_id, relation_fields):
+            diags.append(
+                Diagnostic(
+                    HE_T003,
+                    "error",
+                    "identifiers.relation_id",
+                    f"Field {name!r} is not defined in output.relations",
+                )
+            )
+
+    diags.extend(
+        _check_relation_members(config.type, relation_members, relation_fields, config)
+    )
+    return diags
+
+
+def _check_relation_members(
+    autotype: str,
+    members: Any,
+    relation_fields: set[str],
+    config: TemplateCfg,
+) -> list[Diagnostic]:
+    diags: list[Diagnostic] = []
+    if members is None:
+        diags.append(
+            Diagnostic(
+                HE_T003,
+                "error",
+                "identifiers.relation_members",
+                "relation_members is required for graph templates",
+            )
+        )
+        return diags
+
+    if autotype in BINARY_GRAPH_TYPES:
+        if not isinstance(members, dict):
+            diags.append(
+                Diagnostic(
+                    HE_T004,
+                    "error",
+                    "identifiers.relation_members",
+                    f"{autotype} requires relation_members to be a dict "
+                    "mapping roles to edge field names",
+                )
+            )
+            return diags
+        if not members:
+            diags.append(
+                Diagnostic(
+                    HE_T003,
+                    "error",
+                    "identifiers.relation_members",
+                    "relation_members dict must map at least one edge field",
+                )
+            )
+            return diags
+        for role, field_name in members.items():
+            if field_name not in relation_fields:
+                diags.append(
+                    Diagnostic(
+                        HE_T003,
+                        "error",
+                        f"identifiers.relation_members.{role}",
+                        f"Field {field_name!r} is not defined in output.relations",
+                    )
+                )
+        return diags
+
+    if autotype == "hypergraph":
+        if isinstance(members, dict):
+            diags.append(
+                Diagnostic(
+                    HE_T004,
+                    "error",
+                    "identifiers.relation_members",
+                    "hypergraph requires relation_members to be a string "
+                    "or a list of field names, not a dict",
+                )
+            )
+            return diags
+        if isinstance(members, str):
+            names = [members] if members else []
+        elif isinstance(members, list):
+            names = list(members)
+        else:
+            diags.append(
+                Diagnostic(
+                    HE_T004,
+                    "error",
+                    "identifiers.relation_members",
+                    "hypergraph requires relation_members to be a string or list",
+                )
+            )
+            return diags
+        if not names:
+            diags.append(
+                Diagnostic(
+                    HE_T003,
+                    "error",
+                    "identifiers.relation_members",
+                    "relation_members must name at least one relation field",
+                )
+            )
+            return diags
+
+        relation_schema = (
+            _field_map(config.output.relations)
+            if isinstance(config.output, GraphOutputSchema)
+            else {}
+        )
+        for name in names:
+            if name not in relation_fields:
+                diags.append(
+                    Diagnostic(
+                        HE_T003,
+                        "error",
+                        "identifiers.relation_members",
+                        f"Field {name!r} is not defined in output.relations",
+                    )
+                )
+                continue
+            field_schema = relation_schema.get(name)
+            if field_schema is not None and field_schema.type != "list":
+                diags.append(
+                    Diagnostic(
+                        HE_T004,
+                        "error",
+                        "identifiers.relation_members",
+                        f"Hypergraph member field {name!r} must have type: list",
+                    )
+                )
+        return diags
+
+    return diags
+
+
+def _check_spatiotemporal(config: TemplateCfg) -> list[Diagnostic]:
+    if config.type not in TEMPORAL_TYPES | SPATIAL_TYPES:
+        return []
+    if not isinstance(config.identifiers, GraphIdentifiersSchema):
+        # Missing/wrong identifiers already reported as HE-T003.
+        return []
+
+    diags: list[Diagnostic] = []
+    fields = _entity_relation_fields(config)
+    relation_fields = fields[1] if fields else set()
+
+    if config.type in TEMPORAL_TYPES:
+        time_field = config.identifiers.time_field
+        if not time_field:
+            diags.append(
+                Diagnostic(
+                    HE_T006,
+                    "error",
+                    "identifiers.time_field",
+                    f"{config.type} requires identifiers.time_field",
+                )
+            )
+        else:
+            for name in _missing_fields(time_field, relation_fields):
+                diags.append(
+                    Diagnostic(
+                        HE_T003,
+                        "error",
+                        "identifiers.time_field",
+                        f"Field {name!r} is not defined in output.relations",
+                    )
+                )
+
+    if config.type in SPATIAL_TYPES:
+        location_field = config.identifiers.location_field
+        if not location_field:
+            diags.append(
+                Diagnostic(
+                    HE_T006,
+                    "error",
+                    "identifiers.location_field",
+                    f"{config.type} requires identifiers.location_field",
+                )
+            )
+        else:
+            for name in _missing_fields(location_field, relation_fields):
+                diags.append(
+                    Diagnostic(
+                        HE_T003,
+                        "error",
+                        "identifiers.location_field",
+                        f"Field {name!r} is not defined in output.relations",
+                    )
+                )
+    return diags
+
+
+def _check_display(config: TemplateCfg) -> list[Diagnostic]:
+    display = config.display
+    diags: list[Diagnostic] = []
+
+    if isinstance(display, NaiveDisplaySchema):
+        available = _record_fields(config)
+        for name in _missing_fields(display.label, available, placeholders_only=True):
+            diags.append(
+                Diagnostic(
+                    HE_T005,
+                    "error",
+                    "display.label",
+                    f"Placeholder {{{name}}} is not defined in output.fields",
+                )
+            )
+        return diags
+
+    if not isinstance(display, GraphDisplaySchema):
+        return diags
+
+    fields = _entity_relation_fields(config)
+    if fields is None:
+        return diags
+    entity_fields, relation_fields = fields
+
+    for name in _missing_fields(
+        display.entity_label, entity_fields, placeholders_only=True
+    ):
+        diags.append(
+            Diagnostic(
+                HE_T005,
+                "error",
+                "display.entity_label",
+                f"Placeholder {{{name}}} is not defined in output.entities",
+            )
+        )
+    for name in _missing_fields(
+        display.relation_label, relation_fields, placeholders_only=True
+    ):
+        diags.append(
+            Diagnostic(
+                HE_T005,
+                "error",
+                "display.relation_label",
+                f"Placeholder {{{name}}} is not defined in output.relations",
+            )
+        )
+    return diags
+
+
+def _declared_languages(config: TemplateCfg) -> list[str]:
+    if isinstance(config.language, list):
+        return [str(lang) for lang in config.language]
+    return [str(config.language)]
+
+
+def _is_lang_dict(value: object) -> bool:
+    if not isinstance(value, dict) or not value:
+        return False
+    return all(isinstance(key, str) and _LANG_KEY_RE.match(key) for key in value)
+
+
+def _walk_bilingual(value: Any, path: str, langs: list[str]) -> list[Diagnostic]:
+    diags: list[Diagnostic] = []
+    if _is_lang_dict(value):
+        for lang in langs:
+            entry = value.get(lang)
+            missing = lang not in value or entry is None or entry == "" or entry == []
+            if missing:
+                diags.append(
+                    Diagnostic(
+                        HE_T007,
+                        "warning",
+                        f"{path}.{lang}" if path else lang,
+                        f"Missing {lang!r} text on a bilingual field",
+                    )
+                )
+        return diags
+    if isinstance(value, dict):
+        for key, child in value.items():
+            child_path = f"{path}.{key}" if path else str(key)
+            diags.extend(_walk_bilingual(child, child_path, langs))
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            diags.extend(_walk_bilingual(child, f"{path}[{index}]", langs))
+    return diags
+
+
+def _check_bilingual(config: TemplateCfg) -> list[Diagnostic]:
+    langs = _declared_languages(config)
+    payload = {
+        "description": config.description,
+        "output": config.output.model_dump(),
+        "guideline": config.guideline.model_dump(),
+    }
+    return _walk_bilingual(payload, "", langs)
+
+
+def _check_field_count(config: TemplateCfg) -> list[Diagnostic]:
+    if not isinstance(config.output, GraphOutputSchema):
+        return []
+    diags: list[Diagnostic] = []
+    entity_count = len(config.output.entities.fields)
+    relation_count = len(config.output.relations.fields)
+    if entity_count > FIELD_COUNT_LIMIT:
+        diags.append(
+            Diagnostic(
+                HE_T008,
+                "warning",
+                "output.entities.fields",
+                f"Entity schema has {entity_count} fields "
+                f"(DESIGN_GUIDE limit is {FIELD_COUNT_LIMIT})",
+            )
+        )
+    if relation_count > FIELD_COUNT_LIMIT:
+        diags.append(
+            Diagnostic(
+                HE_T008,
+                "warning",
+                "output.relations.fields",
+                f"Relation schema has {relation_count} fields "
+                f"(DESIGN_GUIDE limit is {FIELD_COUNT_LIMIT})",
+            )
+        )
+    return diags
+
+
+def _is_under_presets(path: Path) -> bool:
+    try:
+        path.resolve().relative_to(_presets_dir().resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def _domain_for(path: Path) -> str:
+    presets = _presets_dir()
+    try:
+        relative = path.resolve().relative_to(presets.resolve())
+        if relative.parts:
+            return relative.parts[0]
+    except ValueError:
+        pass
+    return path.parent.name
+
+
+@lru_cache(maxsize=1)
+def _preset_key_index() -> dict[str, tuple[Path, ...]]:
+    presets = _presets_dir()
+    index: dict[str, list[Path]] = {}
+    if not presets.is_dir():
+        return {}
+    for file_path in presets.rglob("*.yaml"):
+        try:
+            with open(file_path, encoding="utf-8") as handle:
+                raw = yaml.safe_load(handle)
+        except (OSError, yaml.YAMLError):
+            continue
+        if not isinstance(raw, dict) or "name" not in raw:
+            continue
+        domain = file_path.parent.relative_to(presets).parts[0]
+        index.setdefault(f"{domain}/{raw['name']}", []).append(file_path)
+    return {key: tuple(paths) for key, paths in index.items()}
+
+
+def _preset_files_for_key(key: str) -> list[Path]:
+    return list(_preset_key_index().get(key, ()))
+
+
+def _check_gallery_collision(path: Path, config: TemplateCfg) -> list[Diagnostic]:
+    domain = _domain_for(path)
+    if not domain:
+        return []
+    key = f"{domain}/{config.name}"
+    if _is_under_presets(path):
+        others = [
+            other
+            for other in _preset_files_for_key(key)
+            if other.resolve() != path.resolve()
+        ]
+        if not others:
+            return []
+        return [
+            Diagnostic(
+                HE_T009,
+                "warning",
+                "name",
+                f"Gallery key {key!r} is used by another preset: {others[0]}",
+            )
+        ]
+
+    if key in Gallery.list():
+        return [
+            Diagnostic(
+                HE_T009,
+                "warning",
+                "name",
+                f"Gallery already has a template named {key!r}",
+            )
+        ]
+    return []
+
+
+__all__ = [
+    "BINARY_GRAPH_TYPES",
+    "FIELD_COUNT_LIMIT",
+    "GRAPH_TYPES",
+    "HE_T001",
+    "HE_T002",
+    "HE_T003",
+    "HE_T004",
+    "HE_T005",
+    "HE_T006",
+    "HE_T007",
+    "HE_T008",
+    "HE_T009",
+    "Diagnostic",
+    "ValidationResult",
+    "iter_template_files",
+    "validate_template",
+    "validate_template_dir",
+]

--- a/hyperextract/utils/template_engine/validator.py
+++ b/hyperextract/utils/template_engine/validator.py
@@ -4,6 +4,11 @@
 documented in ``hyperextract-skills/yaml-validator/`` so authors can catch
 identifier, display, and spatiotemporal mistakes before extraction.
 
+Each ``HE-T*`` rule points at the matching skill file and
+``hyperextract/templates/DESIGN_GUIDE.md`` section. Lookup of fixes:
+``hyperextract-skills/yaml-validator/references/rules-errors.md`` and
+DESIGN_GUIDE Part 5 Common Errors.
+
 The runtime loader is intentionally left unchanged.
 """
 
@@ -133,10 +138,15 @@ def validate_template_dir(directory: str | Path) -> list[ValidationResult]:
 
 
 def validate_template(path: str | Path) -> ValidationResult:
-    """Validate one template YAML file.
+    """Validate one template YAML file (HE-T001 through HE-T009).
 
     Returns a :class:`ValidationResult`. ``ok`` is True when there are no
     error-severity diagnostics (warnings do not fail the result).
+
+    See also:
+        hyperextract-skills/yaml-validator/SKILL.md
+        hyperextract-skills/yaml-validator/references/rules-errors.md
+        hyperextract/templates/DESIGN_GUIDE.md (Part 5 Validation, Common Errors)
     """
     file_path = Path(path)
     result = ValidationResult(file=str(file_path))
@@ -174,6 +184,12 @@ def validate_template(path: str | Path) -> ValidationResult:
 
 
 def _load_yaml(path: Path) -> tuple[dict[str, Any] | None, list[Diagnostic]]:
+    """Parse YAML text (HE-T001).
+
+    See also:
+        hyperextract-skills/yaml-validator/references/rules-syntax.md
+        hyperextract/templates/DESIGN_GUIDE.md (Part 5 Validation)
+    """
     try:
         with open(path, encoding="utf-8") as handle:
             raw = yaml.safe_load(handle)
@@ -205,6 +221,12 @@ def _load_yaml(path: Path) -> tuple[dict[str, Any] | None, list[Diagnostic]]:
 def _parse_config(
     raw: dict[str, Any],
 ) -> tuple[TemplateCfg | None, list[Diagnostic]]:
+    """Match the document to ``TemplateCfg`` (HE-T002).
+
+    See also:
+        hyperextract-skills/yaml-validator/references/rules-types.md
+        hyperextract/templates/DESIGN_GUIDE.md (Part 2 Type-Specific Design)
+    """
     try:
         return TemplateCfg(**raw), []
     except ValidationError as exc:
@@ -242,6 +264,12 @@ def _check_localize(config: TemplateCfg) -> list[Diagnostic]:
 
 
 def _check_output_shape(config: TemplateCfg) -> list[Diagnostic]:
+    """Require type-specific output keys (HE-T002).
+
+    See also:
+        hyperextract-skills/yaml-validator/references/rules-types.md
+        hyperextract/templates/DESIGN_GUIDE.md (Part 2 Type-Specific Design)
+    """
     if config.type in GRAPH_TYPES and not isinstance(config.output, GraphOutputSchema):
         return [
             Diagnostic(
@@ -314,6 +342,12 @@ def _record_fields(config: TemplateCfg) -> set[str]:
 
 
 def _check_identifiers(config: TemplateCfg) -> list[Diagnostic]:
+    """Check identifier field references (HE-T003).
+
+    See also:
+        hyperextract-skills/yaml-validator/references/rules-identifiers.md
+        hyperextract/templates/DESIGN_GUIDE.md (Part 3 Identifiers Configuration)
+    """
     if config.type in RECORD_TYPES:
         return _check_record_identifiers(config)
     if config.type in GRAPH_TYPES:
@@ -440,6 +474,18 @@ def _check_relation_members(
     relation_fields: set[str],
     config: TemplateCfg,
 ) -> list[Diagnostic]:
+    """Check ``relation_members`` shape vs AutoType (HE-T004).
+
+    Binary graph types require a dict whose values name edge-schema fields
+    (direction preserved). Hypergraph requires a string or list of list-typed
+    relation fields, not a dict.
+
+    See also:
+        hyperextract-skills/yaml-validator/references/rules-identifiers.md
+            (Binary Relations, Hypergraph)
+        hyperextract/templates/DESIGN_GUIDE.md
+            (Part 2 graph vs hypergraph)
+    """
     diags: list[Diagnostic] = []
     if members is None:
         diags.append(
@@ -555,6 +601,14 @@ def _check_relation_members(
 
 
 def _check_spatiotemporal(config: TemplateCfg) -> list[Diagnostic]:
+    """Require ``time_field`` / ``location_field`` (HE-T006).
+
+    See also:
+        hyperextract-skills/yaml-validator/references/rules-identifiers.md
+            (Temporal Graph, Spatial Graph)
+        hyperextract/templates/DESIGN_GUIDE.md
+            (Part 2 temporal_graph / spatial_graph)
+    """
     if config.type not in TEMPORAL_TYPES | SPATIAL_TYPES:
         return []
     if not isinstance(config.identifiers, GraphIdentifiersSchema):
@@ -612,6 +666,12 @@ def _check_spatiotemporal(config: TemplateCfg) -> list[Diagnostic]:
 
 
 def _check_display(config: TemplateCfg) -> list[Diagnostic]:
+    """Check display ``{placeholder}`` names (HE-T005).
+
+    See also:
+        hyperextract-skills/yaml-validator/SKILL.md (Field validation)
+        hyperextract/templates/DESIGN_GUIDE.md (Part 3 Display Configuration)
+    """
     display = config.display
     diags: list[Diagnostic] = []
 
@@ -700,6 +760,11 @@ def _walk_bilingual(value: Any, path: str, langs: list[str]) -> list[Diagnostic]
 
 
 def _check_bilingual(config: TemplateCfg) -> list[Diagnostic]:
+    """Warn when declared languages are missing on bilingual fields (HE-T007).
+
+    See also:
+        hyperextract/templates/DESIGN_GUIDE.md (Part 4 Multi-language Rules)
+    """
     langs = _declared_languages(config)
     payload = {
         "description": config.description,
@@ -710,6 +775,13 @@ def _check_bilingual(config: TemplateCfg) -> list[Diagnostic]:
 
 
 def _check_field_count(config: TemplateCfg) -> list[Diagnostic]:
+    """Warn when entity/relation field count exceeds the DESIGN_GUIDE limit (HE-T008).
+
+    See also:
+        hyperextract-skills/yaml-validator/SKILL.md (Validation Levels)
+        hyperextract/templates/DESIGN_GUIDE.md
+            (Quick Reference Field Count Guidelines, Part 4 Field Count Optimization)
+    """
     if not isinstance(config.output, GraphOutputSchema):
         return []
     diags: list[Diagnostic] = []
@@ -781,6 +853,11 @@ def _preset_files_for_key(key: str) -> list[Path]:
 
 
 def _check_gallery_collision(path: Path, config: TemplateCfg) -> list[Diagnostic]:
+    """Warn when ``domain/name`` collides with a Gallery preset (HE-T009).
+
+    See also:
+        hyperextract/templates/DESIGN_GUIDE.md (Appendix Template Directory Structure)
+    """
     domain = _domain_for(path)
     if not domain:
         return []

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,7 @@ plugins:
                     - cli/commands/talk.md
                     - cli/commands/info.md
                     - cli/commands/list.md
+                    - cli/commands/template.md
                     - cli/commands/config.md
                 - cli/configuration.md
             - MCP Server: mcp.md
@@ -175,6 +176,7 @@ plugins:
                     - zh/cli/commands/talk.md
                     - zh/cli/commands/info.md
                     - zh/cli/commands/list.md
+                    - zh/cli/commands/template.md
                     - zh/cli/commands/config.md
                 - zh/cli/configuration.md
             - MCP 服务器: zh/mcp.md

--- a/tests/cli/test_template_validate.py
+++ b/tests/cli/test_template_validate.py
@@ -127,11 +127,34 @@ class TestTemplateValidateCli:
         assert result.exit_code == 0, result.output
 
     def test_batch_presets_only_known_error(self):
-        result = runner.invoke(app, ["template", "validate", str(PRESETS_DIR), "--all"])
+        result = runner.invoke(
+            app, ["template", "validate", str(PRESETS_DIR), "--all", "--json"]
+        )
         # general/workflow_graph.yaml is temporal_graph without time_field.
+        # Education presets added in v0.5.0 must not fail.
         assert result.exit_code == 1
-        assert "workflow_graph.yaml" in result.output
-        assert "HE-T006" in result.output
+        payload = json.loads(result.output)
+        assert payload["ok"] is False
+        failed = [item for item in payload["results"] if not item["ok"]]
+        assert len(failed) == 1
+        assert failed[0]["file"].replace("\\", "/").endswith(
+            "general/workflow_graph.yaml"
+        )
+        error_codes = {
+            diagnostic["code"]
+            for diagnostic in failed[0]["diagnostics"]
+            if diagnostic["severity"] == "error"
+        }
+        assert error_codes == {"HE-T006"}
+        education = [
+            item
+            for item in payload["results"]
+            if item["file"].replace("\\", "/").endswith(
+                ("course_concept_graph.yaml", "curriculum_structure.yaml")
+            )
+        ]
+        assert len(education) == 2
+        assert all(item["ok"] for item in education)
 
     def test_batch_json_wraps_results(self, tmp_path):
         _write(tmp_path, VALID_GRAPH, name="a.yaml")

--- a/tests/cli/test_template_validate.py
+++ b/tests/cli/test_template_validate.py
@@ -1,0 +1,146 @@
+"""Tests for the `he template validate` command."""
+
+import json
+from pathlib import Path
+from textwrap import dedent
+
+from typer.testing import CliRunner
+
+from hyperextract.cli.cli import app
+
+runner = CliRunner()
+
+PRESETS_DIR = (
+    Path(__file__).resolve().parents[2] / "hyperextract" / "templates" / "presets"
+)
+
+VALID_GRAPH = """
+language: en
+name: ValidGraph
+type: graph
+tags: [test]
+description: A valid graph template
+output:
+  description: graph output
+  entities:
+    description: entities
+    fields:
+      - name: name
+        type: str
+        description: entity name
+  relations:
+    description: relations
+    fields:
+      - name: source
+        type: str
+        description: source entity
+      - name: target
+        type: str
+        description: target entity
+      - name: type
+        type: str
+        description: relation type
+guideline:
+  target: Extract entities and relations
+  rules_for_entities: Keep names stable
+  rules_for_relations: Only explicit links
+identifiers:
+  entity_id: name
+  relation_id: '{source}|{type}|{target}'
+  relation_members:
+    source: source
+    target: target
+display:
+  entity_label: '{name}'
+  relation_label: '{type}'
+"""
+
+
+def _write(tmp_path: Path, content: str, name: str = "template.yaml") -> Path:
+    path = tmp_path / name
+    path.write_text(dedent(content).lstrip(), encoding="utf-8")
+    return path
+
+
+class TestTemplateValidateCli:
+    def test_valid_template_exits_zero(self, tmp_path):
+        path = _write(tmp_path, VALID_GRAPH)
+        result = runner.invoke(app, ["template", "validate", str(path)])
+        assert result.exit_code == 0
+        assert "OK" in result.output
+
+    def test_identifier_error_exits_one(self, tmp_path):
+        path = _write(tmp_path, VALID_GRAPH.replace("entity_id: name", "entity_id: nope"))
+        result = runner.invoke(app, ["template", "validate", str(path)])
+        assert result.exit_code == 1
+        assert "HE-T003" in result.output
+        assert "FAILED" in result.output
+
+    def test_warning_only_exits_zero(self, tmp_path):
+        yaml_text = VALID_GRAPH.replace(
+            "language: en\nname: ValidGraph",
+            "language: [zh, en]\nname: ValidGraph",
+        ).replace(
+            "description: A valid graph template",
+            "description:\n  en: A valid graph template",
+        )
+        path = _write(tmp_path, yaml_text)
+        result = runner.invoke(app, ["template", "validate", str(path)])
+        assert result.exit_code == 0
+        assert "HE-T007" in result.output
+
+    def test_json_output_is_parseable(self, tmp_path):
+        path = _write(
+            tmp_path, VALID_GRAPH.replace("entity_id: name", "entity_id: missing")
+        )
+        result = runner.invoke(app, ["template", "validate", str(path), "--json"])
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["ok"] is False
+        assert payload["file"] == str(path)
+        assert isinstance(payload["diagnostics"], list)
+        item = payload["diagnostics"][0]
+        assert set(item) == {"code", "severity", "path", "message"}
+        assert item["code"] == "HE-T003"
+
+    def test_json_success_shape(self, tmp_path):
+        path = _write(tmp_path, VALID_GRAPH)
+        result = runner.invoke(app, ["template", "validate", str(path), "--json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload == {"file": str(path), "diagnostics": [], "ok": True}
+
+    def test_directory_requires_all(self, tmp_path):
+        _write(tmp_path, VALID_GRAPH)
+        result = runner.invoke(app, ["template", "validate", str(tmp_path)])
+        assert result.exit_code == 1
+        assert "--all" in result.output
+
+    def test_batch_valid_directory_is_green(self, tmp_path):
+        _write(tmp_path, VALID_GRAPH, name="a.yaml")
+        _write(
+            tmp_path,
+            VALID_GRAPH.replace("name: ValidGraph", "name: Other"),
+            name="b.yaml",
+        )
+        result = runner.invoke(app, ["template", "validate", str(tmp_path), "--all"])
+        assert result.exit_code == 0, result.output
+
+    def test_batch_presets_only_known_error(self):
+        result = runner.invoke(app, ["template", "validate", str(PRESETS_DIR), "--all"])
+        # general/workflow_graph.yaml is temporal_graph without time_field.
+        assert result.exit_code == 1
+        assert "workflow_graph.yaml" in result.output
+        assert "HE-T006" in result.output
+
+    def test_batch_json_wraps_results(self, tmp_path):
+        _write(tmp_path, VALID_GRAPH, name="a.yaml")
+        _write(tmp_path, VALID_GRAPH.replace("name: ValidGraph", "name: Other"), name="b.yaml")
+        result = runner.invoke(
+            app, ["template", "validate", str(tmp_path), "--all", "--json"]
+        )
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["ok"] is True
+        assert len(payload["results"]) == 2
+        assert {item["ok"] for item in payload["results"]} == {True}

--- a/tests/template_engine/test_validator.py
+++ b/tests/template_engine/test_validator.py
@@ -1,0 +1,370 @@
+"""Unit tests for the template semantic validator."""
+
+from pathlib import Path
+from textwrap import dedent
+
+from hyperextract.utils.template_engine import (
+    validate_template,
+    validate_template_dir,
+)
+from hyperextract.utils.template_engine.validator import (
+    HE_T001,
+    HE_T002,
+    HE_T003,
+    HE_T004,
+    HE_T005,
+    HE_T006,
+    HE_T007,
+    HE_T008,
+    HE_T009,
+)
+
+PRESETS_DIR = (
+    Path(__file__).resolve().parents[2] / "hyperextract" / "templates" / "presets"
+)
+
+VALID_GRAPH = """
+language: en
+name: ValidGraph
+type: graph
+tags: [test]
+description: A valid graph template
+output:
+  description: graph output
+  entities:
+    description: entities
+    fields:
+      - name: name
+        type: str
+        description: entity name
+      - name: type
+        type: str
+        description: entity type
+  relations:
+    description: relations
+    fields:
+      - name: source
+        type: str
+        description: source entity
+      - name: target
+        type: str
+        description: target entity
+      - name: type
+        type: str
+        description: relation type
+guideline:
+  target: Extract entities and relations
+  rules_for_entities: Keep names stable
+  rules_for_relations: Only explicit links
+identifiers:
+  entity_id: name
+  relation_id: '{source}|{type}|{target}'
+  relation_members:
+    source: source
+    target: target
+display:
+  entity_label: '{name}'
+  relation_label: '{type}'
+"""
+
+VALID_HYPERGRAPH = """
+language: en
+name: ValidHypergraph
+type: hypergraph
+tags: [test]
+description: A valid hypergraph template
+output:
+  description: hypergraph output
+  entities:
+    description: entities
+    fields:
+      - name: name
+        type: str
+        description: entity name
+  relations:
+    description: relations
+    fields:
+      - name: name
+        type: str
+        description: hyperedge name
+      - name: participants
+        type: list
+        description: participating entities
+guideline:
+  target: Extract hyperedges
+  rules_for_entities: Keep names stable
+  rules_for_relations: Group co-participants
+identifiers:
+  entity_id: name
+  relation_id: '{name}'
+  relation_members: participants
+display:
+  entity_label: '{name}'
+  relation_label: '{name}'
+"""
+
+VALID_SET = """
+language: en
+name: ValidSet
+type: set
+tags: [test]
+description: A valid set template
+output:
+  description: set output
+  fields:
+    - name: name
+      type: str
+      description: item name
+guideline:
+  target: Extract items
+  rules: Keep names stable
+identifiers:
+  item_id: name
+display:
+  label: '{name}'
+"""
+
+
+def _write(tmp_path: Path, content: str, name: str = "template.yaml") -> Path:
+    path = tmp_path / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(dedent(content).lstrip(), encoding="utf-8")
+    return path
+
+
+def _codes(result) -> list[str]:
+    return [d.code for d in result.diagnostics]
+
+
+def _by_code(result, code: str):
+    return [d for d in result.diagnostics if d.code == code]
+
+
+class TestValidTemplates:
+    def test_valid_graph_has_no_diagnostics(self, tmp_path):
+        path = _write(tmp_path, VALID_GRAPH)
+        result = validate_template(path)
+        assert result.ok
+        assert result.diagnostics == []
+        assert result.to_dict()["ok"] is True
+        assert result.to_dict()["file"] == str(path)
+
+    def test_valid_hypergraph_has_no_diagnostics(self, tmp_path):
+        result = validate_template(_write(tmp_path, VALID_HYPERGRAPH))
+        assert result.ok
+        assert result.diagnostics == []
+
+    def test_valid_set_has_no_diagnostics(self, tmp_path):
+        result = validate_template(_write(tmp_path, VALID_SET))
+        assert result.ok
+        assert result.diagnostics == []
+
+
+class TestStructureErrors:
+    def test_invalid_yaml(self, tmp_path):
+        path = _write(tmp_path, "name: [\n")
+        result = validate_template(path)
+        assert not result.ok
+        assert HE_T001 in _codes(result)
+
+    def test_invalid_schema_type(self, tmp_path):
+        path = _write(tmp_path, VALID_GRAPH.replace("type: graph", "type: graphh"))
+        result = validate_template(path)
+        assert not result.ok
+        assert HE_T002 in _codes(result)
+
+    def test_missing_file(self, tmp_path):
+        result = validate_template(tmp_path / "missing.yaml")
+        assert not result.ok
+        assert HE_T001 in _codes(result)
+
+
+class TestIdentifierErrors:
+    def test_missing_entity_field(self, tmp_path):
+        yaml_text = VALID_GRAPH.replace("entity_id: name", "entity_id: nickname")
+        result = validate_template(_write(tmp_path, yaml_text))
+        assert not result.ok
+        diags = _by_code(result, HE_T003)
+        assert diags
+        assert diags[0].path == "identifiers.entity_id"
+        assert "nickname" in diags[0].message
+
+    def test_relation_members_dict_value_must_be_edge_field(self, tmp_path):
+        yaml_text = VALID_GRAPH.replace(
+            "    source: source\n    target: target",
+            "    source: src\n    target: target",
+        )
+        result = validate_template(_write(tmp_path, yaml_text))
+        assert not result.ok
+        diags = _by_code(result, HE_T003)
+        assert any(d.path == "identifiers.relation_members.source" for d in diags)
+
+    def test_graph_members_must_be_dict(self, tmp_path):
+        yaml_text = VALID_GRAPH.replace(
+            "  relation_members:\n    source: source\n    target: target",
+            "  relation_members: participants",
+        )
+        result = validate_template(_write(tmp_path, yaml_text))
+        assert not result.ok
+        assert HE_T004 in _codes(result)
+
+    def test_hypergraph_members_must_not_be_dict(self, tmp_path):
+        yaml_text = VALID_HYPERGRAPH.replace(
+            "  relation_members: participants",
+            "  relation_members:\n    source: source\n    target: target",
+        )
+        result = validate_template(_write(tmp_path, yaml_text))
+        assert not result.ok
+        assert HE_T004 in _codes(result)
+
+    def test_hypergraph_member_field_must_be_list_type(self, tmp_path):
+        yaml_text = VALID_HYPERGRAPH.replace(
+            "      - name: participants\n        type: list",
+            "      - name: participants\n        type: str",
+        )
+        result = validate_template(_write(tmp_path, yaml_text))
+        assert not result.ok
+        assert HE_T004 in _codes(result)
+
+
+class TestDisplayErrors:
+    def test_entity_label_unknown_placeholder(self, tmp_path):
+        yaml_text = VALID_GRAPH.replace(
+            "  entity_label: '{name}'",
+            "  entity_label: '{title}'",
+        )
+        result = validate_template(_write(tmp_path, yaml_text))
+        assert not result.ok
+        diags = _by_code(result, HE_T005)
+        assert diags
+        assert diags[0].path == "display.entity_label"
+        assert "title" in diags[0].message
+
+    def test_constant_display_label_is_allowed(self, tmp_path):
+        yaml_text = VALID_SET.replace("  label: '{name}'", "  label: '出院指导'")
+        result = validate_template(_write(tmp_path, yaml_text))
+        assert result.ok
+        assert HE_T005 not in _codes(result)
+
+
+class TestSpatiotemporalErrors:
+    def test_temporal_graph_requires_time_field(self, tmp_path):
+        yaml_text = VALID_GRAPH.replace("type: graph", "type: temporal_graph")
+        result = validate_template(_write(tmp_path, yaml_text))
+        assert not result.ok
+        diags = _by_code(result, HE_T006)
+        assert any(d.path == "identifiers.time_field" for d in diags)
+
+    def test_spatial_graph_requires_location_field(self, tmp_path):
+        yaml_text = VALID_GRAPH.replace("type: graph", "type: spatial_graph")
+        result = validate_template(_write(tmp_path, yaml_text))
+        assert not result.ok
+        diags = _by_code(result, HE_T006)
+        assert any(d.path == "identifiers.location_field" for d in diags)
+
+    def test_spatio_temporal_requires_both(self, tmp_path):
+        yaml_text = VALID_GRAPH.replace("type: graph", "type: spatio_temporal_graph")
+        result = validate_template(_write(tmp_path, yaml_text))
+        assert not result.ok
+        paths = {d.path for d in _by_code(result, HE_T006)}
+        assert "identifiers.time_field" in paths
+        assert "identifiers.location_field" in paths
+
+
+class TestWarningsDoNotFail:
+    def test_bilingual_gap_is_warning(self, tmp_path):
+        yaml_text = VALID_GRAPH.replace(
+            "language: en\nname: ValidGraph",
+            "language: [zh, en]\nname: ValidGraph",
+        ).replace(
+            "description: A valid graph template",
+            "description:\n  en: A valid graph template",
+        )
+        result = validate_template(_write(tmp_path, yaml_text))
+        assert result.ok
+        assert result.error_count == 0
+        assert HE_T007 in _codes(result)
+        assert all(d.severity == "warning" for d in _by_code(result, HE_T007))
+
+    def test_field_count_over_limit_is_warning(self, tmp_path):
+        extra_fields = "\n".join(
+            f"      - name: extra_{i}\n        type: str\n        description: extra"
+            for i in range(4)
+        )
+        yaml_text = VALID_GRAPH.replace(
+            "      - name: type\n        type: str\n        description: entity type",
+            "      - name: type\n        type: str\n        description: entity type\n"
+            + extra_fields,
+        )
+        result = validate_template(_write(tmp_path, yaml_text))
+        assert result.ok
+        diags = _by_code(result, HE_T008)
+        assert diags
+        assert diags[0].severity == "warning"
+        assert diags[0].path == "output.entities.fields"
+
+    def test_gallery_name_collision_is_warning(self, tmp_path):
+        path = _write(
+            tmp_path / "general",
+            VALID_GRAPH.replace("name: ValidGraph", "name: graph"),
+            name="dup.yaml",
+        )
+        result = validate_template(path)
+        assert result.ok
+        diags = _by_code(result, HE_T009)
+        assert diags
+        assert "general/graph" in diags[0].message
+
+
+class TestJsonShape:
+    def test_to_dict_is_stable(self, tmp_path):
+        result = validate_template(
+            _write(
+                tmp_path,
+                VALID_GRAPH.replace("entity_id: name", "entity_id: missing"),
+            )
+        )
+        payload = result.to_dict()
+        assert set(payload) == {"file", "diagnostics", "ok"}
+        assert payload["ok"] is False
+        assert payload["diagnostics"]
+        item = payload["diagnostics"][0]
+        assert set(item) == {"code", "severity", "path", "message"}
+
+
+# Bundled presets that currently fail error-level checks. Do not "fix" them in
+# this change — record and keep the allowlist tight so new errors still fail.
+KNOWN_PRESET_ERRORS = {
+    "general/workflow_graph.yaml": {HE_T006},
+}
+
+
+class TestPresetBootstrap:
+    def test_bundled_presets_have_no_unexpected_errors(self):
+        results = validate_template_dir(PRESETS_DIR)
+        assert results, "expected bundled presets"
+
+        unexpected = []
+        seen_known = set()
+        for item in results:
+            relative = str(Path(item.file).relative_to(PRESETS_DIR)).replace("\\", "/")
+            error_codes = {
+                d.code for d in item.diagnostics if d.severity == "error"
+            }
+            allowed = KNOWN_PRESET_ERRORS.get(relative, set())
+            extra = error_codes - allowed
+            missing = allowed - error_codes
+            if extra or missing:
+                unexpected.append((relative, sorted(error_codes), sorted(allowed)))
+            if relative in KNOWN_PRESET_ERRORS:
+                seen_known.add(relative)
+
+        assert unexpected == []
+        assert seen_known == set(KNOWN_PRESET_ERRORS)
+
+        collisions = [
+            item.file
+            for item in results
+            if any(d.code == HE_T009 for d in item.diagnostics)
+        ]
+        assert collisions == []


### PR DESCRIPTION
## Motivation

Tracking issue: #77. Owner accepted the scope and asked for this PR.

`load_template()` only validates YAML shape. Identifier references, display placeholders, and temporal/spatial fields otherwise fail at extraction time. This makes the `hyperextract-skills/yaml-validator/` checklist executable.

## Design (aligned with the #77 notes)

- Sidecar only: `load_template()` behavior unchanged; bundled preset YAML not edited.
- Python: `validate_template` / `validate_template_dir` in `hyperextract/utils/template_engine/`.
- CLI: `he template validate PATH [--json] [--all]` on a `he template` Typer group.
- `HE-T004` / dict `relation_members` follow #74 (values name edge fields; direction preserved).
- `--json --all` emits `{"results": [per-file report including `ok`], "ok": <all ok>}` — a list of reports plus an aggregate. Exit `1` iff any file has error-severity diagnostics; warnings never fail.
- Each `HE-T*` rule docstring points at `hyperextract-skills/yaml-validator/` and `templates/DESIGN_GUIDE.md`.

## Bundled presets

`he template validate hyperextract/templates/presets --all` reports **one** known error: `general/workflow_graph.yaml` is `temporal_graph` without `time_field` (HE-T006). Education presets added in v0.5.0 are clean. This PR does not edit that historical preset. Happy to open a follow-up if you want it retagged as `graph` or given an explicit `time_field`.

## Tests

Unit tests from the acceptance list (happy path, one fixture per error class, warning-does-not-fail, JSON shape, preset bootstrap with that single allowlisted error, CliRunner exit codes).

## Compatibility

New API and command only. Rebased onto v0.5.0 (`3fcf9f1`). `Fixes #77`

Made with [Cursor](https://cursor.com)