### PR TITLE
fix: restrict config.toml permissions to 0600 on save

### DIFF
--- a/docs/en/cli/configuration.md
+++ b/docs/en/cli/configuration.md
@@ -227,6 +227,8 @@ Running `he config init` automatically creates `~/.he/config.toml`.
 - **Linux/macOS**: `~/.he/config.toml`
 - **Windows**: `%USERPROFILE%\.he\config.toml`
 
+On Linux/macOS, `he config` saves this file as mode `0600` (owner read/write only). If an existing file is group- or world-readable, the CLI warns on load and tightens the mode on the next save. Prefer environment variables over writing API keys into the file.
+
 ### Configuration Format
 
 === "Cloud API — Bailian"

--- a/docs/zh/cli/configuration.md
+++ b/docs/zh/cli/configuration.md
@@ -227,6 +227,8 @@ he config embedder --unset
 - **Linux/macOS**: `~/.he/config.toml`
 - **Windows**: `%USERPROFILE%\.he\config.toml`
 
+在 Linux / macOS 上，`he config` 会以 `0600`（仅文件所有者可读写）写入该文件。若已有文件对组或其他用户可读，加载时会给出 warning，下次保存会收紧权限。更推荐用环境变量，而不是把 API key 写入文件。
+
 ### 配置格式
 
 === "云 API — 百炼"

--- a/hyperextract/cli/config.py
+++ b/hyperextract/cli/config.py
@@ -1,6 +1,7 @@
 """Configuration management for Hyper-Extract CLI."""
 
 import json
+import logging
 import os
 import tomllib
 from dataclasses import dataclass
@@ -8,6 +9,12 @@ from pathlib import Path
 from typing import Any
 
 import tomli_w
+
+logger = logging.getLogger(__name__)
+
+# Owner read/write only. Group/other bits that make a file too open.
+_CONFIG_FILE_MODE = 0o600
+_GROUP_OTHER_BITS = 0o077
 
 DEFAULT_CONFIG_DIR = Path.home() / ".he"
 DEFAULT_CONFIG_FILE = DEFAULT_CONFIG_DIR / "config.toml"
@@ -66,6 +73,33 @@ def _env_api_key(provider: str) -> str:
         if value:
             return value
     return ""
+
+
+def _restrict_config_permissions(path: Path) -> None:
+    """Set *path* to owner read/write only (0600). Best-effort on Windows."""
+    try:
+        os.chmod(path, _CONFIG_FILE_MODE)
+    except OSError:
+        pass
+
+
+def _warn_if_insecure_permissions(path: Path) -> None:
+    """Warn when group or others can read the config file. Unix-only."""
+    if os.name == "nt":
+        return
+    try:
+        mode = path.stat().st_mode
+    except OSError:
+        return
+    if mode & _GROUP_OTHER_BITS:
+        logger.warning(
+            "Config file %s is readable by group or others (mode %04o). "
+            "The next `he config` save will tighten it to 0600, "
+            "or run: chmod 600 %s",
+            path,
+            mode & 0o777,
+            path,
+        )
 
 
 @dataclass
@@ -132,6 +166,8 @@ class ConfigManager:
         if not self.config_path.exists():
             return
 
+        _warn_if_insecure_permissions(self.config_path)
+
         with open(self.config_path, "rb") as f:
             data = tomllib.load(f)
 
@@ -153,6 +189,7 @@ class ConfigManager:
 
         with open(self.config_path, "wb") as f:
             tomli_w.dump(data, f)
+        _restrict_config_permissions(self.config_path)
 
     def _resolve_base_url(self, provider: str, explicit_base_url: str) -> str:
         """Resolve base_url from provider preset. Explicit value takes precedence."""

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -1,6 +1,19 @@
 """Tests for ConfigManager persistence."""
 
+import logging
+import os
+
+import pytest
+
 from hyperextract.cli.config import ConfigManager
+
+# Fixture-only dummy; never a real key from the environment.
+_FAKE_API_KEY = "sk-test"
+
+_POSIX_ONLY = pytest.mark.skipif(
+    os.name == "nt",
+    reason="POSIX file modes are not enforced on Windows",
+)
 
 
 def test_save_creates_custom_parent_dir(tmp_path):
@@ -15,3 +28,47 @@ def test_save_creates_custom_parent_dir(tmp_path):
     # Round-trips back through a fresh manager.
     reloaded = ConfigManager(cfg_path)
     assert reloaded.llm.model == "gpt-4o-mini"
+
+
+@_POSIX_ONLY
+def test_save_sets_owner_only_permissions(tmp_path):
+    cfg_path = tmp_path / "config.toml"
+    mgr = ConfigManager(cfg_path)
+    mgr.set_llm(provider="openai", model="gpt-4o-mini", api_key=_FAKE_API_KEY)
+
+    assert cfg_path.stat().st_mode & 0o777 == 0o600
+
+
+@_POSIX_ONLY
+def test_save_tightens_existing_world_readable_file(tmp_path):
+    cfg_path = tmp_path / "config.toml"
+    cfg_path.write_text(
+        '[llm]\nprovider = "openai"\nmodel = "gpt-4o-mini"\n'
+        f'api_key = "{_FAKE_API_KEY}"\nbase_url = ""\n',
+        encoding="utf-8",
+    )
+    cfg_path.chmod(0o644)
+    assert cfg_path.stat().st_mode & 0o777 == 0o644
+
+    mgr = ConfigManager(cfg_path)
+    mgr.set_llm(provider="openai", api_key=_FAKE_API_KEY)
+
+    assert cfg_path.stat().st_mode & 0o777 == 0o600
+
+
+@_POSIX_ONLY
+def test_load_warns_when_config_is_group_or_world_readable(tmp_path, caplog):
+    cfg_path = tmp_path / "config.toml"
+    cfg_path.write_text(
+        '[llm]\nprovider = "openai"\nmodel = "gpt-4o-mini"\n'
+        f'api_key = "{_FAKE_API_KEY}"\nbase_url = ""\n',
+        encoding="utf-8",
+    )
+    cfg_path.chmod(0o644)
+
+    with caplog.at_level(logging.WARNING, logger="hyperextract.cli.config"):
+        ConfigManager(cfg_path)
+
+    assert caplog.records
+    assert any("0600" in record.getMessage() for record in caplog.records)
+    assert _FAKE_API_KEY not in caplog.text


### PR DESCRIPTION
## Problem

`he config` writes API keys into `~/.he/config.toml` with whatever mode the process umask produces. On typical Unix setups that is `0644`, so group and other users can read the file.

## Fix

On POSIX, after a successful save, chmod the config file to `0600` (owner read/write only). Loading a file that is still group- or world-readable only logs a warning and still succeeds, so existing configs are not bricked; the next save tightens the mode. Windows chmod failures are swallowed and do not raise. This is file-mode restriction only — not Keychain, and not encryption. Keys remain plaintext on disk.

## Tests

`tests/cli/test_config.py` uses `tmp_path`. Dummy keys are `sk-test` / `sk-x` only. POSIX asserts mode `0600` after save and a warning (without the key plaintext) on load of a `0644` file. Windows skips mode assertions but must not throw.

## Compatibility

Config is still plaintext on disk. Environment variables still override stored keys. Rebased onto current `main`, which includes #83.


Made with [Cursor](https://cursor.com)