### PR TITLE
fix: escape wikilink metacharacters in Obsidian alias text

### DIFF
--- a/hyperextract/utils/obsidian.py
+++ b/hyperextract/utils/obsidian.py
@@ -32,6 +32,8 @@ logger = get_logger(__name__)
 # file names. ``[`` / ``]`` / ``#`` / ``^`` / ``|`` break wikilink parsing.
 _ILLEGAL_FILENAME_CHARS = re.compile(r'[\\/:*?"<>|\[\]#^]')
 _WHITESPACE = re.compile(r"\s+")
+# Characters that break an Obsidian wikilink alias ("[[stem|alias]]").
+_WIKILINK_METACHARS = re.compile(r"[\[\]|#^]")
 
 # Conservative "safe to emit unquoted" YAML plain-scalar charset.
 _SAFE_PLAIN = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9 _./()\-]*$")
@@ -165,6 +167,9 @@ def sanitize_filename(name: str, fallback: str = "untitled") -> str:
 
 def _wikilink(stem: str, display: str | None = None) -> str:
     """Build an Obsidian wikilink targeting ``stem`` with optional display text."""
+    if display:
+        # An alias can't contain wikilink metacharacters, or the link breaks.
+        display = _WHITESPACE.sub(" ", _WIKILINK_METACHARS.sub(" ", display)).strip()
     if display and display != stem:
         return f"[[{stem}|{display}]]"
     return f"[[{stem}]]"

--- a/tests/utils/test_obsidian_wikilink.py
+++ b/tests/utils/test_obsidian_wikilink.py
@@ -1,0 +1,19 @@
+"""Tests for Obsidian wikilink alias escaping."""
+
+from hyperextract.utils.obsidian import _wikilink
+
+
+def test_alias_strips_brackets():
+    # "Array[0]" sanitizes to stem "Array 0"; the alias must not reintroduce [ ].
+    out = _wikilink("Array 0", "Array[0]")
+    assert out == "[[Array 0]]"
+
+
+def test_alias_strips_pipe():
+    out = _wikilink("A B", "A | B")
+    assert out.count("|") == 0
+    assert out == "[[A B]]"
+
+
+def test_normal_alias_preserved():
+    assert _wikilink("apple", "Apple Inc") == "[[apple|Apple Inc]]"


### PR DESCRIPTION
## Problem
`_wikilink(stem, display)` in the Obsidian exporter emits `[[{stem}|{display}]]`. The `stem` is sanitized by `sanitize_filename` (which strips wikilink-breaking chars `[ ] | # ^`), but `display` (the raw node/edge title) is not. The alias is only added when `display != stem` — which happens exactly when the title contained an illegal char that got stripped from the stem. So the broken alias is produced in precisely the cases where the title still holds a wikilink-breaking character.

Example: title `Array[0]` → stem `Array 0` → output `[[Array 0|Array[0]]]`. Obsidian stops matching the alias at the first `]`, so the link renders incorrectly with a stray `]`. A title containing `|` injects a second alias separator.

## Fix
Strip wikilink metacharacters (`[ ] | # ^`) from `display` inside `_wikilink` (and collapse whitespace) before building the alias. Applied once at the root, so both call sites (relationship links and index links) are covered. If the cleaned alias equals the stem, a plain `[[stem]]` is emitted.

## Tests
`tests/utils/test_obsidian_wikilink.py`: bracketed and piped titles no longer break the link; a normal alias (`Apple Inc`) is preserved. The metachar cases fail on the pre-fix code.

`ruff check`/`ruff format --check` on `hyperextract` clean; existing `test_obsidian_export` still passes.
