### PR TITLE
fix: keep one archived copy per source on re-feed

### DIFF
--- a/hyperextract/utils/document_store.py
+++ b/hyperextract/utils/document_store.py
@@ -39,6 +39,10 @@ class SourceDocumentStore:
     ) -> Path:
         """Archive text content (used for stdin feeds)."""
         self.root.mkdir(parents=True, exist_ok=True)
+        # Keep one current copy per source: drop prior archives whose filename
+        # differs (the original basename is part of the name), so re-feeding the
+        # same source_id overwrites rather than accumulating stale copies.
+        self.purge(source_id)
         path = self.path_for(source_id, original_name)
         path.write_text(text, encoding="utf-8")
         return path
@@ -47,6 +51,7 @@ class SourceDocumentStore:
         """Archive an original file (raw bytes preserved)."""
         src = Path(input_path)
         self.root.mkdir(parents=True, exist_ok=True)
+        self.purge(source_id)
         dst = self.path_for(source_id, src.name)
         shutil.copy2(src, dst)
         return dst

--- a/tests/utils/test_document_store.py
+++ b/tests/utils/test_document_store.py
@@ -1,0 +1,41 @@
+"""Tests for SourceDocumentStore's one-copy-per-source invariant."""
+
+from hyperextract.utils.document_store import SourceDocumentStore
+
+
+def test_refeed_same_source_different_name_overwrites(tmp_path):
+    """Re-feeding a source with a different filename keeps a single current copy."""
+    store = SourceDocumentStore(tmp_path)
+
+    store.store_text("doc1", "version one", original_name="a.txt")
+    store.store_text("doc1", "version two", original_name="b.txt")
+
+    archived = store.find("doc1")
+    assert len(archived) == 1
+    assert archived[0].read_text(encoding="utf-8") == "version two"
+
+
+def test_store_file_overwrites_prior_copy(tmp_path):
+    """store_file also drops a prior archive for the same source."""
+    store = SourceDocumentStore(tmp_path)
+    first = tmp_path / "first.txt"
+    first.write_text("one", encoding="utf-8")
+    second = tmp_path / "second.txt"
+    second.write_text("two", encoding="utf-8")
+
+    store.store_file("doc1", first)
+    store.store_file("doc1", second)
+
+    archived = store.find("doc1")
+    assert len(archived) == 1
+    assert archived[0].read_text(encoding="utf-8") == "two"
+
+
+def test_distinct_sources_kept_separately(tmp_path):
+    """Different source_ids don't clobber each other."""
+    store = SourceDocumentStore(tmp_path)
+    store.store_text("doc1", "a", original_name="x.txt")
+    store.store_text("doc2", "b", original_name="x.txt")
+
+    assert len(store.find("doc1")) == 1
+    assert len(store.find("doc2")) == 1


### PR DESCRIPTION
## Problem
`SourceDocumentStore` archives a source document as `documents/<sha256(source_id)[:12]>-<original basename>`, and its docstring promises:

> This keeps one *current* copy per source: re-feeding the same source_id overwrites the archived file, mirroring the ledger's bounded "current version per source" policy.

But the filename also embeds the original **basename**, which is independent of `source_id` — the CLI passes `--source` and the input file separately (`store_file(source, input)`). Re-feeding the same `source_id` from a differently-named input therefore writes a **second** archive instead of overwriting, so the "one current copy" invariant silently breaks and stale copies accumulate (and `find()`/`purge()` then return multiples).

## Fix
`store_text` and `store_file` now `purge(source_id)` before writing, dropping any prior archive for that source regardless of its stored basename. This upholds the documented overwrite-on-refeed contract while keeping the human-readable filename.

## Tests
Added `tests/utils/test_document_store.py` (the module had no tests): re-feeding a source with a different filename leaves exactly one current copy for both `store_text` and `store_file`, and distinct `source_id`s are kept separate. The overwrite cases fail on the pre-fix code.

`ruff check`/`ruff format --check` on `hyperextract` clean.
