### PR TITLE
fix: forward source_ids/tags scope in AutoHypergraph.search

### DIFF
--- a/hyperextract/types/hypergraph.py
+++ b/hyperextract/types/hypergraph.py
@@ -795,12 +795,16 @@ class AutoHypergraph(
         if top_k_nodes > 0:
             if not self._node_memory.has_index():
                 raise ValueError("Node index not built. Call build_index() first.")
-            nodes = self.search_nodes(query, top_k=top_k_nodes)
+            nodes = self.search_nodes(
+                query, top_k=top_k_nodes, source_ids=source_ids, tags=tags
+            )
 
         if top_k_edges > 0:
             if not self._edge_memory.has_index():
                 raise ValueError("Edge index not built. Call build_index() first.")
-            edges = self.search_edges(query, top_k=top_k_edges)
+            edges = self.search_edges(
+                query, top_k=top_k_edges, source_ids=source_ids, tags=tags
+            )
 
         return nodes, edges
 

--- a/tests/types/test_hypergraph_search_scope.py
+++ b/tests/types/test_hypergraph_search_scope.py
@@ -1,0 +1,50 @@
+"""AutoHypergraph.search must forward source_ids/tags scope to the helpers."""
+
+from typing import List
+
+from pydantic import BaseModel, Field
+
+from hyperextract.types import AutoHypergraph
+
+
+class _Entity(BaseModel):
+    name: str
+    type: str = "x"
+
+
+class _HyperRelation(BaseModel):
+    participants: List[str]
+    relation_type: str
+
+
+def _hypergraph(llm_client, embedder):
+    hg = AutoHypergraph(
+        node_schema=_Entity,
+        edge_schema=_HyperRelation,
+        node_key_extractor=lambda x: x.name,
+        edge_key_extractor=lambda x: f"{x.relation_type}_{sorted(x.participants)}",
+        nodes_in_edge_extractor=lambda x: tuple(x.participants),
+        llm_client=llm_client,
+        embedder=embedder,
+    )
+    hg._node_memory.add([_Entity(name="Apple")])
+    hg._edge_memory.add(
+        [_HyperRelation(participants=["Apple", "Steve"], relation_type="founded_by")]
+    )
+    hg.build_index()
+    return hg
+
+
+def test_search_forwards_scope(llm_client, embedder):
+    hg = _hypergraph(llm_client, embedder)
+
+    seen = {}
+    hg.search_nodes = lambda query, **kw: seen.setdefault("nodes", kw) or []
+    hg.search_edges = lambda query, **kw: seen.setdefault("edges", kw) or []
+
+    hg.search("q", source_ids=["s1"], tags=["t1"])
+
+    assert seen["nodes"]["source_ids"] == ["s1"]
+    assert seen["nodes"]["tags"] == ["t1"]
+    assert seen["edges"]["source_ids"] == ["s1"]
+    assert seen["edges"]["tags"] == ["t1"]


### PR DESCRIPTION
## Problem
`AutoHypergraph.search()` declares `source_ids` / `tags` scope parameters (for `he search --source/--tag`), but when it fans out to the per-type helpers it passes only `top_k`:

```python
nodes = self.search_nodes(query, top_k=top_k_nodes)   # source_ids/tags dropped
edges = self.search_edges(query, top_k=top_k_edges)   # source_ids/tags dropped
```

`search_nodes`/`search_edges` both accept and forward `source_ids`/`tags`, so the scope machinery works — the top-level `search()` just never hands it down. As a result a scoped hypergraph search silently returns **unscoped** results (no error). The sibling `AutoGraph.search()` forwards the scope correctly; hypergraph is the copy that lost it.

## Fix
Forward `source_ids=source_ids, tags=tags` to both `search_nodes` and `search_edges`, matching `AutoGraph.search()`.

## Tests
`tests/types/test_hypergraph_search_scope.py`: spies on the helpers and asserts `search(query, source_ids=[...], tags=[...])` forwards the scope to both. Fails on the pre-fix code.

`ruff check`/`ruff format --check` on `hyperextract` clean.
