### PR TITLE
fix: require source/target roles in binary relation_members validation

### DIFF
--- a/hyperextract/utils/template_engine/validator.py
+++ b/hyperextract/utils/template_engine/validator.py
@@ -520,6 +520,20 @@ def _check_relation_members(
                 )
             )
             return diags
+        # The extractor (parsers/identifiers.py) reads members["source"] and
+        # members["target"] directly, so both roles are required — otherwise the
+        # template validates but raises KeyError at extraction time.
+        for required_role in ("source", "target"):
+            if required_role not in members:
+                diags.append(
+                    Diagnostic(
+                        HE_T003,
+                        "error",
+                        "identifiers.relation_members",
+                        f"Binary graph relation_members must define a "
+                        f"{required_role!r} role",
+                    )
+                )
         for role, field_name in members.items():
             if field_name not in relation_fields:
                 diags.append(

--- a/tests/template_engine/test_validator.py
+++ b/tests/template_engine/test_validator.py
@@ -199,6 +199,20 @@ class TestIdentifierErrors:
         diags = _by_code(result, HE_T003)
         assert any(d.path == "identifiers.relation_members.source" for d in diags)
 
+    def test_relation_members_must_define_source_and_target_roles(self, tmp_path):
+        # Non-standard role keys ("from"/"to") whose VALUES are valid edge
+        # fields: the extractor reads members["source"]/["target"], so the
+        # validator must reject this instead of letting it KeyError at runtime.
+        yaml_text = VALID_GRAPH.replace(
+            "    source: source\n    target: target",
+            "    from: source\n    to: target",
+        )
+        result = validate_template(_write(tmp_path, yaml_text))
+        assert not result.ok
+        diags = _by_code(result, HE_T003)
+        assert any("source" in d.message for d in diags)
+        assert any("target" in d.message for d in diags)
+
     def test_graph_members_must_be_dict(self, tmp_path):
         yaml_text = VALID_GRAPH.replace(
             "  relation_members:\n    source: source\n    target: target",


### PR DESCRIPTION
## Problem
For binary graph templates, `_check_relation_members` only verifies that each `relation_members` dict **value** names a valid edge field — it accepts arbitrary **keys**:

```python
for role, field_name in members.items():
    if field_name not in relation_fields:
        diags.append(Diagnostic(HE_T003, "error", ...))
```

But the runtime extractor (`parsers/identifiers.py`) reads the roles by name:

```python
source_field = members["source"]
target_field = members["target"]
```

So a template like `relation_members: {from: source, to: target}` (whose values *are* valid edge fields) **passes validation** and then raises `KeyError: 'source'` at extraction time — precisely the failure the validator is meant to catch ahead of time.

## Fix
In the binary-graph branch, require the `relation_members` dict to define both a `source` and a `target` role, emitting an `HE-T003` error for each missing one.

## Tests
`tests/template_engine/test_validator.py`: a graph template using non-standard role keys (`from`/`to`) with valid field values is now rejected with `source`/`target` diagnostics. The full validator suite — including `TestPresetBootstrap`, which validates every bundled preset clean — still passes (all presets already use `source`/`target`). The new test fails on the pre-fix code.

`ruff check`/`ruff format --check` on `hyperextract` clean.
