### PR TITLE
docs: directory parse includes ingest-supported files

### DIFF
--- a/docs/en/cli/commands/parse.md
+++ b/docs/en/cli/commands/parse.md
@@ -86,7 +86,7 @@ he parse document.md -o ./output/ -l en
 
 ### Process a Directory
 
-Extract from all `.md` and `.txt` files in a directory:
+Directory mode is non-recursive and reads supported files in that folder (`.txt`/`.md` always; PDF/DOCX/… when `hyperextract[ingest]` is installed); other regular files at the same level are skipped with a warning.
 
 ```bash
 he parse ./documents/ -t general/concept_graph -o ./output/ -l en

--- a/docs/zh/cli/commands/parse.md
+++ b/docs/zh/cli/commands/parse.md
@@ -82,7 +82,7 @@ he parse document.md -o ./output/ -l zh
 
 ### 处理目录
 
-从目录中的所有 `.md` 和 `.txt` 文件提取：
+目录模式非递归：读取该目录下受支持的文件（`.txt`/`.md` 始终支持；安装 `hyperextract[ingest]` 后还包括 PDF/DOCX 等）；同层其它常规文件会 warning 并跳过：
 
 ```bash
 he parse ./documents/ -t general/concept_graph -o ./output/ -l zh


### PR DESCRIPTION
## Problem

In v0.9.0, directory mode reads ingest-supported files (PDF, DOCX, and others) once `hyperextract[ingest]` is installed. The English and Chinese `he parse` “Process a Directory” / “处理目录” examples still said extraction was limited to `.md` and `.txt`.

## Fix

Align those example sentences with the Supported input formats table and `collect_directory_text_inputs`: directory mode is non-recursive, `.txt`/`.md` are always read, PDF/DOCX/… are included when the ingest extra is installed, and other regular files at the same level are skipped with a warning.

## Compatibility

Docs-only. No code or CLI behavior change.


Made with [Cursor](https://cursor.com)