### PR TITLE
fix: honor ORCAROUTER_API_KEY in CLI ConfigManager

### DIFF
--- a/hyperextract/cli/commands/config.py
+++ b/hyperextract/cli/commands/config.py
@@ -151,7 +151,7 @@ def llm(
         None,
         "--provider",
         "-p",
-        help="Provider preset: openai, anthropic, deepseek, bailian, vllm",
+        help="Provider preset: openai, anthropic, deepseek, bailian, orcarouter, vllm",
     ),
     api_key: str | None = typer.Option(
         None,
@@ -212,7 +212,7 @@ def embedder(
         None,
         "--provider",
         "-p",
-        help="Provider preset: openai, anthropic, deepseek, bailian, vllm",
+        help="Provider preset: openai, anthropic, deepseek, bailian, orcarouter, vllm",
     ),
     api_key: str | None = typer.Option(
         None,
@@ -275,7 +275,7 @@ def init(
         None,
         "--provider",
         "-p",
-        help="Provider preset: openai, anthropic, deepseek, bailian, vllm",
+        help="Provider preset: openai, anthropic, deepseek, bailian, orcarouter, vllm",
     ),
     api_key: str | None = typer.Option(
         None,
@@ -372,6 +372,8 @@ def init(
         ("openai", "OpenAI", "https://api.openai.com/v1"),
         ("bailian", "阿里云百炼", "https://dashscope.aliyuncs.com/compatible-mode/v1"),
         ("deepseek", "DeepSeek", "https://api.deepseek.com"),
+        ("orcarouter", "OrcaRouter", "https://api.orcarouter.ai/v1"),
+        ("anthropic", "Anthropic (Claude)", "native SDK"),
         ("vllm", "本地 vLLM", "自定义地址"),
         ("custom", "其他 OpenAI 兼容接口", "自定义地址"),
     ]

--- a/hyperextract/cli/config.py
+++ b/hyperextract/cli/config.py
@@ -10,6 +10,8 @@ from typing import Any
 
 import tomli_w
 
+from hyperextract.utils.client import PROVIDER_API_KEY_ENV, PROVIDER_PRESETS
+
 logger = logging.getLogger(__name__)
 
 # Owner read/write only. Group/other bits that make a file too open.
@@ -18,49 +20,6 @@ _GROUP_OTHER_BITS = 0o077
 
 DEFAULT_CONFIG_DIR = Path.home() / ".he"
 DEFAULT_CONFIG_FILE = DEFAULT_CONFIG_DIR / "config.toml"
-
-# Provider presets: base_url and default models for each provider
-PROVIDER_PRESETS: dict[str, dict[str, str | None]] = {
-    "openai": {
-        "base_url": "https://api.openai.com/v1",
-        "default_llm": "gpt-4o-mini",
-        "default_embedder": "text-embedding-3-small",
-    },
-    "bailian": {
-        "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
-        "default_llm": "qwen3.6-plus",
-        "default_embedder": "text-embedding-v4",
-    },
-    "vllm": {
-        "base_url": None,
-        "default_llm": None,
-        "default_embedder": None,
-    },
-    # DeepSeek: OpenAI-compatible, no embeddings API.
-    "deepseek": {
-        "base_url": "https://api.deepseek.com",
-        "default_llm": "deepseek-v4-flash",
-        "default_embedder": None,
-    },
-    # Anthropic (Claude): native client, no base_url, no embeddings API.
-    "anthropic": {
-        "base_url": "",
-        "default_llm": "claude-opus-4-8",
-        "default_embedder": None,
-    },
-    "claude": {
-        "base_url": "",
-        "default_llm": "claude-opus-4-8",
-        "default_embedder": None,
-    },
-}
-
-# Environment variables checked (in order) for each provider's API key.
-PROVIDER_API_KEY_ENV: dict[str, tuple] = {
-    "anthropic": ("ANTHROPIC_API_KEY", "CLAUDE_API_KEY"),
-    "claude": ("ANTHROPIC_API_KEY", "CLAUDE_API_KEY"),
-    "deepseek": ("DEEPSEEK_API_KEY",),
-}
 
 
 def _env_api_key(provider: str) -> str:

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -72,3 +72,52 @@ def test_load_warns_when_config_is_group_or_world_readable(tmp_path, caplog):
     assert caplog.records
     assert any("0600" in record.getMessage() for record in caplog.records)
     assert _FAKE_API_KEY not in caplog.text
+
+
+def test_cli_provider_tables_are_library_presets():
+    """CLI must not keep a drifting copy of library provider tables."""
+    from hyperextract.cli import config as cli_config
+    from hyperextract.utils.client import PROVIDER_API_KEY_ENV, PROVIDER_PRESETS
+
+    assert cli_config.PROVIDER_PRESETS is PROVIDER_PRESETS
+    assert cli_config.PROVIDER_API_KEY_ENV is PROVIDER_API_KEY_ENV
+    assert "orcarouter" in cli_config.PROVIDER_PRESETS
+    assert cli_config.PROVIDER_API_KEY_ENV["orcarouter"] == ("ORCAROUTER_API_KEY",)
+
+
+def test_get_llm_config_reads_orcarouter_env_key(tmp_path, monkeypatch):
+    """Empty toml api_key must resolve ORCAROUTER_API_KEY for orcarouter."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-from-env")
+
+    cm = ConfigManager(tmp_path / "config.toml")
+    cm.set_llm(provider="orcarouter", model="orcarouter/auto", api_key="")
+    cfg = cm.get_llm_config()
+
+    assert cfg.api_key == "sk-orca-from-env"
+    assert cfg.base_url == "https://api.orcarouter.ai/v1"
+
+
+def test_get_llm_config_orcarouter_key_beats_openai_key(tmp_path, monkeypatch):
+    """ORCAROUTER_API_KEY must win over OPENAI_API_KEY for orcarouter."""
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-must-not-win")
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-preferred")
+
+    cm = ConfigManager(tmp_path / "config.toml")
+    cm.set_llm(provider="orcarouter", api_key="")
+    cfg = cm.get_llm_config()
+
+    assert cfg.api_key == "sk-orca-preferred"
+
+
+def test_interactive_init_lists_orcarouter_and_anthropic():
+    """he config init provider list must match library presets."""
+    import inspect
+
+    from hyperextract.cli.commands.config import init
+
+    source = inspect.getsource(init)
+    assert '"orcarouter"' in source
+    assert '"anthropic"' in source


### PR DESCRIPTION
﻿## Summary
- Import `PROVIDER_PRESETS` and `PROVIDER_API_KEY_ENV` from `hyperextract.utils.client` so CLI `ConfigManager` resolves `ORCAROUTER_API_KEY` and the orcarouter preset URL.
- Add `orcarouter` and `anthropic` to interactive `he config init`.

## Out of scope
- New Gemini/Google named presets
- `create_llm` thinking / tool_choice behavior
- Default model name changes

## Test plan
- [x] `uv run pytest tests/cli/test_config.py tests/utils/test_client.py -q`
- [x] `uv run pytest -q` (541 passed, 15 skipped)
- [x] `ruff check hyperextract` and `ruff format --check hyperextract`
- [x] Empty toml `api_key` + `ORCAROUTER_API_KEY` resolves that key; `OPENAI_API_KEY` does not win

Closes #95
