### PR TITLE
feat: wire AutoDocument as YAML type and public export

### DIFF
--- a/docs/en/python/index.md
+++ b/docs/en/python/index.md
@@ -68,7 +68,7 @@ ka = Template.create("method/light_rag")
 
 ### Auto-Types
 
-Eight data structure types for different extraction needs:
+Eight data structure types for different extraction needs, plus `AutoDocument` for chunk-only corpora (`type: document` in YAML; no LLM extraction).
 
 | Class | Use Case |
 |-------|----------|

--- a/docs/zh/python/index.md
+++ b/docs/zh/python/index.md
@@ -68,7 +68,7 @@ ka = Template.create("method/light_rag")
 
 ### 自动类型
 
-8 种用于不同提取需求的数据结构类型：
+8 种用于不同提取需求的数据结构类型，另有 `AutoDocument` 用于只切块、不走 LLM 抽取的语料（YAML `type: document`）。
 
 | 类 | 用例 |
 |-------|----------|

--- a/hyperextract/__init__.py
+++ b/hyperextract/__init__.py
@@ -25,6 +25,7 @@ Usage:
 from importlib.metadata import version
 
 from .types import (
+    AutoDocument,
     AutoGraph,
     AutoHypergraph,
     AutoList,
@@ -50,6 +51,8 @@ __author__ = "Yifan Feng"
 __email__ = "evanfeng97@gmail.com"
 
 __all__ = [
+    # Corpus type
+    "AutoDocument",
     # Graph types
     "AutoGraph",
     "AutoHypergraph",

--- a/hyperextract/utils/template_engine/factory.py
+++ b/hyperextract/utils/template_engine/factory.py
@@ -1,6 +1,7 @@
 """Template Factory - Dynamically creates template instances from configuration.
 
-Supports all 8 AutoType dynamic generation.
+Supports AutoType generation for model, list, set, document, graph,
+hypergraph, temporal_graph, spatial_graph, and spatio_temporal_graph.
 """
 
 from pathlib import Path
@@ -21,6 +22,7 @@ from .parsers import (
 
 if TYPE_CHECKING:
     from hyperextract.types import (
+        AutoDocument,
         AutoGraph,
         AutoHypergraph,
         AutoList,
@@ -376,6 +378,24 @@ class TemplateFactory:
         )
 
     @classmethod
+    def create_document(
+        cls,
+        config: TemplateCfg,
+        llm_client: BaseChatModel,
+        embedder: Embeddings,
+        **kwargs,
+    ) -> "AutoDocument":
+        """Create AutoDocument template (chunk corpus, no LLM extraction)."""
+        from hyperextract.types import AutoDocument
+
+        options = parse_option(config.options, config.type, override=kwargs)
+        return AutoDocument(
+            llm_client=llm_client,
+            embedder=embedder,
+            **options,
+        )
+
+    @classmethod
     def create(
         cls,
         source: str | TemplateCfg,
@@ -473,6 +493,10 @@ class TemplateFactory:
                 template = cls.create_list(template_cfg, llm_client, embedder, **kwargs)
             case "set":
                 template = cls.create_set(template_cfg, llm_client, embedder, **kwargs)
+            case "document":
+                template = cls.create_document(
+                    template_cfg, llm_client, embedder, **kwargs
+                )
             case "graph":
                 template = cls.create_graph(
                     template_cfg, llm_client, embedder, **kwargs

--- a/hyperextract/utils/template_engine/parsers/loader.py
+++ b/hyperextract/utils/template_engine/parsers/loader.py
@@ -92,7 +92,7 @@ def _localize_output(
     autotype: VALID_AUTOTYPES,
 ) -> NaiveOutputSchema | GraphOutputSchema:
     """Localize output configuration."""
-    if autotype in ("model", "list", "set"):
+    if autotype in ("model", "list", "set", "document"):
         return _localize_naive_output(output, language)
     return GraphOutputSchema(
         description=_localize_data(output.description, language),
@@ -107,7 +107,7 @@ def _localize_guideline(
     autotype: VALID_AUTOTYPES,
 ) -> NaiveGuidelineSchema | GraphGuidelineSchema:
     """Localize guideline configuration."""
-    if autotype in ("model", "list", "set"):
+    if autotype in ("model", "list", "set", "document"):
         return NaiveGuidelineSchema(
             target=_localize_data(guideline.target, language),
             rules=_localize_data(guideline.rules, language),

--- a/hyperextract/utils/template_engine/parsers/options.py
+++ b/hyperextract/utils/template_engine/parsers/options.py
@@ -131,6 +131,9 @@ def parse_option(
     if autotype in ("set",):
         return _build_kwargs(options, SET_PARAMS, COMMON_PARAMS)
 
+    if autotype in ("document",):
+        return _build_kwargs(options, (), COMMON_PARAMS)
+
     if autotype in ("graph", "hypergraph"):
         return _build_kwargs(options, GRAPH_PARAMS, COMMON_PARAMS)
 

--- a/hyperextract/utils/template_engine/parsers/schemas/base.py
+++ b/hyperextract/utils/template_engine/parsers/schemas/base.py
@@ -14,6 +14,7 @@ VALID_AUTOTYPES = Literal[
     "model",
     "list",
     "set",
+    "document",
     "graph",
     "hypergraph",
     "temporal_graph",

--- a/tests/template_engine/test_factory.py
+++ b/tests/template_engine/test_factory.py
@@ -125,3 +125,50 @@ class TestTemplateFactoryCreateAllTypes:
 
         assert isinstance(result, AutoGraph)
         assert result.metadata.get("type") == "graph"
+
+
+_DOCUMENT_YAML = """
+language: en
+name: document_fixture
+type: document
+tags: [test]
+description: Minimal AutoDocument fixture (chunk corpus, no LLM extraction).
+output:
+  description: Unused; AutoDocument stores raw chunks.
+  fields:
+  - name: content
+    type: str
+    description: Placeholder required by TemplateCfg.
+guideline:
+  target: Unused; AutoDocument does not extract.
+  rules:
+  - Chunk text only; do not invent graph schema.
+display:
+  label: '{content}'
+"""
+
+
+class TestTemplateFactoryDocumentType:
+    def test_create_document_yaml_type(self, tmp_path, llm_client, embedder):
+        yaml_path = tmp_path / "document.yaml"
+        yaml_path.write_text(_DOCUMENT_YAML, encoding="utf-8")
+
+        from hyperextract.utils.template_engine import Template
+
+        result = Template.create(
+            str(yaml_path),
+            "en",
+            llm_client,
+            embedder,
+        )
+
+        from hyperextract import AutoDocument
+
+        assert isinstance(result, AutoDocument)
+        assert result.metadata["type"] == "document"
+
+    def test_public_import_autodocument(self):
+        from hyperextract import AutoDocument as Exported
+        from hyperextract.types import AutoDocument as Canonical
+
+        assert Exported is Canonical


### PR DESCRIPTION
﻿## Summary
- Export `AutoDocument` from `hyperextract` (`__all__`).
- YAML `type: document` creates an `AutoDocument` via `Template.create` / `TemplateFactory`; options map `chunk_size` / `chunk_overlap` only (no graph schema).
- One-line mention in the English and Chinese Python index pages.

## Out of scope
- `chunk_rag` algorithm changes
- Existing graph presets
- New preset YAML
- DESIGN_GUIDE rewrite

## Test plan
- [x] `uv run pytest tests/types/test_document.py tests/template_engine/ tests/methods/test_chunk_rag.py -q`
- [x] `uv run pytest -q` (539 passed, 15 skipped)
- [x] `ruff check hyperextract` and `ruff format --check hyperextract`
- [x] `from hyperextract import AutoDocument`; YAML fixture `metadata["type"] == "document"`

Closes #99
