### PR TITLE
docs: list tag, remove, and clean on the bare he banner

### DIFF
--- a/hyperextract/cli/cli.py
+++ b/hyperextract/cli/cli.py
@@ -153,6 +153,20 @@ def main(
                     ),
                 ],
             ),
+            make_section(
+                "🛠️ Manage Knowledge Abstract (KA)",
+                [
+                    (
+                        "he tag <ka_path> --source ...",
+                        "Tag a source document",
+                    ),
+                    (
+                        "he remove <ka_path> ...",
+                        "Delete nodes, edges, facts, or documents",
+                    ),
+                    ("he clean <ka_path>", "Remove index or the whole KA"),
+                ],
+            ),
         ]
 
         for section in sections:

--- a/tests/cli/test_verbose.py
+++ b/tests/cli/test_verbose.py
@@ -119,6 +119,14 @@ class TestCLINoVerboseFlag:
         result = runner.invoke(app, ["config", "--help"])
         assert result.exit_code == 0
 
+    def test_bare_he_banner_lists_manage_commands(self):
+        """No-arg `he` banner includes tag, remove, and clean."""
+        result = runner.invoke(app, [])
+        assert result.exit_code == 0
+        assert "he tag" in result.output
+        assert "he remove" in result.output
+        assert "he clean" in result.output
+
     def test_info_missing_ka_exits_with_error(self):
         """he info <nonexistent> exits with error."""
         result = runner.invoke(app, ["info", "/nonexistent/path"])


### PR DESCRIPTION
﻿## Summary
- Bare `he` banner adds a Manage panel for `he tag`, `he remove`, and `he clean`.
- Docs already listed these commands; this only fills the no-arg banner gap.

## Out of scope
- Command implementations
- Emoji / Panel restyle
- CLI docs pages

## Test plan
- [x] `uv run pytest tests/cli/test_verbose.py -q`
- [x] `uv run pytest -q`
- [x] CliRunner on no-arg `he` contains `he tag`, `he remove`, `he clean`

Closes #101
