### PR TITLE
ci: run the test matrix on windows-latest with Python 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,11 +26,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.11", "3.12"]
         exclude:
           # Reduce CI time by excluding some combinations
           - os: macos-latest
+            python-version: "3.11"
+          - os: windows-latest
             python-version: "3.11"
 
     steps:


### PR DESCRIPTION
﻿## Summary
- Add `windows-latest` to the Tests workflow OS matrix.
- Exclude `windows-latest` + Python 3.11 (Windows runs 3.12 only), matching the existing macos-3.11 skip.
- `fail-fast` stays `false`. `integration.yml` is unchanged.

## Out of scope
- GUI install in CI
- Test code changes to paper over Windows
- Nightly integration workflow

## Test plan
- [x] `uv run pytest -q` locally (537 passed, 15 skipped)
- [ ] GitHub Actions `Test Python 3.12 on windows-latest`

Closes #107
