### PR TITLE
fix: pretty-print graph search tuples on he search

### DIFF
--- a/hyperextract/cli/cli.py
+++ b/hyperextract/cli/cli.py
@@ -816,6 +816,81 @@ def info(
             )
 
 
+def _search_item_payload(result):
+    """Serialize one search hit for JSON printing."""
+    if hasattr(result, "model_dump"):
+        return result.model_dump()
+    if hasattr(result, "dict"):
+        return result.dict()
+    return result
+
+
+def _print_search_item(result) -> None:
+    import json
+
+    payload = _search_item_payload(result)
+    if isinstance(payload, (dict, list)):
+        console.print_json(json.dumps(payload, indent=2, ensure_ascii=False))
+    else:
+        console.print(str(result))
+    console.print()
+
+
+def _print_search_section(title: str, items) -> None:
+    console.print(f"[bold cyan]{title}[/bold cyan]")
+    if not items:
+        console.print("[dim](none)[/dim]")
+        console.print()
+        return
+    if isinstance(items, dict):
+        import json
+
+        console.print_json(json.dumps(items, indent=2, ensure_ascii=False))
+        console.print()
+        return
+    for item in items:
+        _print_search_item(item)
+
+
+def _print_search_results(results) -> None:
+    """Print `he search` hits by AutoType return shape (list / tuple / dict)."""
+    if not results:
+        console.print("[yellow]No results found.[/yellow]")
+        return
+
+    if isinstance(results, dict):
+        count = 0
+        for value in results.values():
+            count += len(value) if isinstance(value, list) else 1
+        console.print(f"[bold green]Found {count} result(s):[/bold green]")
+        console.print()
+        preferred = [key for key in ("themes", "entities") if key in results]
+        other = [key for key in results if key not in preferred]
+        for key in preferred + other:
+            title = key[:1].upper() + key[1:] if key else key
+            _print_search_section(title, results[key])
+        return
+
+    if isinstance(results, tuple):
+        nodes = results[0] if len(results) >= 1 else []
+        edges = results[1] if len(results) >= 2 else []
+        community = results[2] if len(results) >= 3 else None
+        count = len(nodes) + len(edges)
+        console.print(f"[bold green]Found {count} result(s):[/bold green]")
+        console.print()
+        _print_search_section("Nodes", nodes)
+        _print_search_section("Edges", edges)
+        if len(results) >= 3 and isinstance(community, dict) and community:
+            _print_search_section("Community", community)
+        return
+
+    console.print(f"[bold green]Found {len(results)} result(s):[/bold green]")
+    console.print()
+    for i, result in enumerate(results, 1):
+        console.print(f"[bold cyan]Result {i}:[/bold cyan]")
+        _print_search_item(result)
+
+
 @app.command(name="search")
 def search(
     ka_path: str = typer.Argument(..., help="Knowledge Abstract directory"),
@@ -830,7 +905,6 @@ def search(
 ):
     """Semantic search in Knowledge Abstract."""
     logger.info("command=search ka_path=%s query=%s top_k=%d", ka_path, query, top_k)
-    import json
 
     validate_config()
 
@@ -883,25 +957,7 @@ def search(
             raise typer.Exit(1)
 
     console.print()
-    if not results:
-        console.print("[yellow]No results found.[/yellow]")
-    else:
-        console.print(f"[bold green]Found {len(results)} result(s):[/bold green]")
-        console.print()
-
-        for i, result in enumerate(results, 1):
-            console.print(f"[bold cyan]Result {i}:[/bold cyan]")
-            if hasattr(result, "model_dump"):
-                console.print_json(
-                    json.dumps(result.model_dump(), indent=2, ensure_ascii=False)
-                )
-            elif hasattr(result, "dict"):
-                console.print_json(
-                    json.dumps(result.dict(), indent=2, ensure_ascii=False)
-                )
-            else:
-                console.print(str(result))
-            console.print()
+    _print_search_results(results)
 
     console.print("[dim]Continue:[/dim]")
     console.print(

--- a/tests/cli/test_search.py
+++ b/tests/cli/test_search.py
@@ -1,0 +1,119 @@
+"""CLI rendering of `he search` across AutoType return shapes."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from pydantic import BaseModel
+from typer.testing import CliRunner
+
+from hyperextract.cli.cli import app
+
+runner = CliRunner()
+
+
+class _Node(BaseModel):
+    name: str
+
+
+class _Edge(BaseModel):
+    source: str
+    target: str
+
+
+class _Theme(BaseModel):
+    title: str
+
+
+def _ka_dir(tmp_path: Path) -> Path:
+    ka = tmp_path / "ka"
+    ka.mkdir()
+    (ka / "data.json").write_text("{}", encoding="utf-8")
+    (ka / "metadata.json").write_text(
+        json.dumps({"template": "general/graph", "lang": "en"}),
+        encoding="utf-8",
+    )
+    index = ka / "index"
+    index.mkdir()
+    (index / "dummy").write_text("x", encoding="utf-8")
+    return ka
+
+
+def _invoke_search(tmp_path, search_return):
+    ka_dir = _ka_dir(tmp_path)
+    fake = MagicMock()
+    fake.search.return_value = search_return
+    fake.load = MagicMock()
+    with (
+        patch("hyperextract.cli.cli.validate_config"),
+        patch("hyperextract.cli.cli.Template.create", return_value=fake),
+    ):
+        return runner.invoke(app, ["search", str(ka_dir), "query"])
+
+
+def test_search_pair_tuple_prints_nodes_and_edges(tmp_path):
+    nodes = [_Node(name="Alice")]
+    edges = [_Edge(source="Alice", target="Bob")]
+    result = _invoke_search(tmp_path, (nodes, edges))
+
+    assert result.exit_code == 0, result.output
+    assert "Nodes" in result.output
+    assert "Edges" in result.output
+    assert "Alice" in result.output
+    assert "Result 1:" not in result.output
+    assert "Found 2 result(s)" in result.output
+
+
+def test_search_triple_prints_community_when_present(tmp_path):
+    nodes = [_Node(name="Alice")]
+    edges = [_Edge(source="Alice", target="Bob")]
+    community = {"summary": "a cluster"}
+    result = _invoke_search(tmp_path, (nodes, edges, community))
+
+    assert result.exit_code == 0, result.output
+    assert "Nodes" in result.output
+    assert "Edges" in result.output
+    assert "Community" in result.output
+    assert "a cluster" in result.output
+    assert "Result 1:" not in result.output
+
+
+def test_search_triple_omits_none_community(tmp_path):
+    nodes = [_Node(name="Alice")]
+    edges = []
+    result = _invoke_search(tmp_path, (nodes, edges, None))
+
+    assert result.exit_code == 0, result.output
+    assert "Nodes" in result.output
+    assert "Community" not in result.output
+
+
+def test_search_list_keeps_numbered_results(tmp_path):
+    result = _invoke_search(tmp_path, [_Node(name="Alice"), _Node(name="Bob")])
+
+    assert result.exit_code == 0, result.output
+    assert "Found 2 result(s)" in result.output
+    assert "Result 1:" in result.output
+    assert "Result 2:" in result.output
+    assert "Alice" in result.output
+
+
+def test_search_dict_sections_themes_and_entities(tmp_path):
+    payload = {
+        "themes": [_Theme(title="power")],
+        "entities": [_Node(name="Tesla")],
+    }
+    result = _invoke_search(tmp_path, payload)
+
+    assert result.exit_code == 0, result.output
+    assert "themes" in result.output.lower() or "Themes" in result.output
+    assert "entities" in result.output.lower() or "Entities" in result.output
+    assert "Tesla" in result.output
+    assert "Result 1:" not in result.output
+
+
+def test_search_empty_list_prints_no_results(tmp_path):
+    result = _invoke_search(tmp_path, [])
+
+    assert result.exit_code == 0, result.output
+    assert "No results found." in result.output


### PR DESCRIPTION
## Summary
- `he search` now prints AutoType results by shape instead of iterating a graph tuple as opaque `Result 1` / `Result 2` lists.
- 2-tuples render `Nodes` / `Edges`; 3-tuples also print `Community` JSON when that dict is non-empty.
- Lists keep numbered `Result N` JSON dumps; cog_rag-style dicts section by key (`themes` / `entities`).
- Empty results still print `No results found.`

Closes #118

## Out of scope
- Changing `AutoType.search` return types
- `he talk --source` / `chat()` `source_ids`
- MCP `search` (follow-up)

## Test plan
- [x] `uv run pytest tests/cli/ -q`
- [x] Fake KA `search` returns 2-tuple, 3-tuple, list, and dict; stdout has `Nodes` and no whole-list `Result 1` dump
