### PR TITLE
fix: unpack graph_rag 3-tuples in MCP search

### DIFF
--- a/hyperextract/mcp_server.py
+++ b/hyperextract/mcp_server.py
@@ -152,8 +152,14 @@ def search(ka_path: str, query: str, top_k: int = 5) -> str:
         query: Natural-language search query.
         top_k: Maximum number of results (for graphs: nodes and edges each).
 
-    Returns matching nodes/edges as JSON. The KA must have an index
-    (build it with `he build-index`).
+    Returns JSON shaped by the AutoType search return:
+
+    - 2-tuple → ``{"nodes": [...], "edges": [...]}``
+    - 3-tuple → same plus ``community_context`` (``null`` is written)
+    - dict → passed through (values via ``_model_to_dict``)
+    - list → ``{"results": [...]}``
+
+    The KA must have an index (build it with `he build-index`).
     """
     ka = _load_ka(ka_path)
     try:
@@ -161,15 +167,24 @@ def search(ka_path: str, query: str, top_k: int = 5) -> str:
     except ValueError as e:
         return f"Cannot search: {e}. Build the index first with `he build-index {ka_path}`."
 
+    return _dump(_search_payload(results))
+
+
+def _search_payload(results: Any) -> Any:
+    """Normalize AutoType search returns into JSON-serializable shapes."""
+    if isinstance(results, dict):
+        return {key: _model_to_dict(value) for key, value in results.items()}
     if isinstance(results, tuple):
-        nodes, edges = results
-        return _dump(
-            {
-                "nodes": [_model_to_dict(n) for n in nodes],
-                "edges": [_model_to_dict(e) for e in edges],
-            }
-        )
-    return _dump({"results": [_model_to_dict(r) for r in results]})
+        nodes = results[0] if len(results) >= 1 else []
+        edges = results[1] if len(results) >= 2 else []
+        payload = {
+            "nodes": [_model_to_dict(n) for n in nodes],
+            "edges": [_model_to_dict(e) for e in edges],
+        }
+        if len(results) >= 3:
+            payload["community_context"] = _model_to_dict(results[2])
+        return payload
+    return {"results": [_model_to_dict(r) for r in results]}
 
 
 def ask(ka_path: str, question: str, top_k: int = 5) -> str:
@@ -306,6 +321,10 @@ def export_csv(ka_path: str, output: str, overwrite: bool = False) -> str:
 def _model_to_dict(item: Any) -> Any:
     if hasattr(item, "model_dump"):
         return item.model_dump()
+    if isinstance(item, list):
+        return [_model_to_dict(x) for x in item]
+    if isinstance(item, dict):
+        return {key: _model_to_dict(value) for key, value in item.items()}
     return item
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -95,6 +95,59 @@ def test_search_returns_nodes_and_edges(monkeypatch):
     assert isinstance(out["nodes"], list)
 
 
+def test_search_graph_rag_triple_includes_community_context(monkeypatch):
+    class _TripleKA:
+        def search(self, query, top_k=5):
+            return (
+                [Entity(name="Alice")],
+                [Relation(source="Alice", target="Bob", relation_type="knows")],
+                {"summary": "cluster"},
+            )
+
+    monkeypatch.setattr(mcp_server, "_load_ka", lambda p: _TripleKA())
+    out = json.loads(mcp_server.search("x", "query"))
+    assert "nodes" in out and "edges" in out
+    assert out["community_context"] == {"summary": "cluster"}
+    assert out["nodes"][0]["name"] == "Alice"
+
+
+def test_search_graph_rag_triple_writes_null_community(monkeypatch):
+    class _TripleKA:
+        def search(self, query, top_k=5):
+            return ([], [], None)
+
+    monkeypatch.setattr(mcp_server, "_load_ka", lambda p: _TripleKA())
+    out = json.loads(mcp_server.search("x", "query"))
+    assert out["nodes"] == []
+    assert out["edges"] == []
+    assert out["community_context"] is None
+
+
+def test_search_list_wraps_results(monkeypatch):
+    class _ListKA:
+        def search(self, query, top_k=5):
+            return [Entity(name="Alice"), Entity(name="Bob")]
+
+    monkeypatch.setattr(mcp_server, "_load_ka", lambda p: _ListKA())
+    out = json.loads(mcp_server.search("x", "query"))
+    assert "results" in out
+    assert [item["name"] for item in out["results"]] == ["Alice", "Bob"]
+
+
+def test_search_dict_passes_through(monkeypatch):
+    class _DictKA:
+        def search(self, query, top_k=5):
+            return {
+                "themes": [Entity(name="power")],
+                "entities": [Entity(name="Tesla")],
+            }
+
+    monkeypatch.setattr(mcp_server, "_load_ka", lambda p: _DictKA())
+    out = json.loads(mcp_server.search("x", "query"))
+    assert out["themes"][0]["name"] == "power"
+    assert out["entities"][0]["name"] == "Tesla"
+
+
 def test_search_without_index_is_handled(monkeypatch):
     g = AutoGraph(
         node_schema=Entity,


### PR DESCRIPTION
## Summary
- MCP `search` no longer unpacks `nodes, edges = results`, which crashed on `graph_rag` 3-tuples.
- 2-tuples stay `{nodes, edges}`; 3-tuples also write `community_context` (including `null`).
- Dicts pass through after `_model_to_dict`; lists stay `{results: [...]}`.

Closes #120

## Out of scope
- `source_ids` / `tags` on MCP search
- `ask` / parse / feed tools
- Sharing CLI print helpers with MCP

## Test plan
- [x] `uv run pytest tests/test_mcp_server.py -q`
- [x] 3-tuple no longer raises; dict and list each have a fixture
