### PR TITLE
fix: require --force before overwriting GraphML exports

### DIFF
--- a/docs/en/cli/commands/export.md
+++ b/docs/en/cli/commands/export.md
@@ -146,6 +146,7 @@ he export graphml KA_PATH -o FILE.graphml
 | Option | Alias | Default | Description |
 |--------|-------|---------|-------------|
 | `--output` | `-o` | *(required)* | Output GraphML file |
+| `--force` | `-f` | `false` | Overwrite an existing, non-empty GraphML file |
 
 ### Description
 
@@ -153,6 +154,7 @@ he export graphml KA_PATH -o FILE.graphml
 - **N-ary hyperedges.** An edge with 3+ incident nodes becomes `<hyperedge>` plus `<endpoint node="…"/>` in the same order `incident_nodes_extractor` returns. Endpoints are never sorted.
 - **Attributes.** Scalar fields from each node's / edge's `model_dump()` (`str` / `int` / `float` / `bool`) become GraphML `<data>` keys. Nested values are stringified. XML special characters (`& < > " '`) are escaped.
 - **Dangling edges.** An edge whose source or target node is missing (or a hyperedge with any missing endpoint) is skipped (with a warning), not treated as a crash.
+- **0/1-endpoint edges.** Edges with fewer than two endpoints are skipped with a warning. This export does not invent a unary GraphML encoding.
 
 Supported Auto-Types: `AutoGraph`, `AutoHypergraph`, and temporal/spatial subclasses. Non-graph types (`AutoList`, `AutoSet`, `AutoModel`) are not supported.
 

--- a/docs/en/cli/index.md
+++ b/docs/en/cli/index.md
@@ -33,7 +33,7 @@ he --version
 | `he parse` | Extract knowledge from documents | `-t` template, `-o` output, `-l` language, `--source` attribution |
 | `he show` | Visualize knowledge graph | — |
 | `he export obsidian` | Export to an Obsidian vault | `-o` output, `--name`, `-f` force |
-| `he export graphml` | Export a pairwise graph to GraphML | `-o` output file |
+| `he export graphml` | Export pairwise `<edge>` and N-ary `<hyperedge>` GraphML | `-o` output file, `-f` force |
 | `he export csv` | Export nodes/edges as CSV tables | `-o` directory, `-f` force |
 | `he search` | Semantic search in knowledge abstract | `-n` top-k results, `--source`, `--tag` |
 | `he talk` | Chat with knowledge abstract | `-i` interactive, `-q` query |
@@ -172,7 +172,7 @@ he show ./output/
 - **[`he talk`](commands/talk.md)** — Chat with knowledge abstract
 - **[`he info`](commands/info.md)** — View knowledge abstract statistics
 - **[`he export obsidian`](commands/export.md)** — Export to an Obsidian vault
-- **[`he export graphml`](commands/export.md#he-export-graphml)** — Export a pairwise graph to GraphML
+- **[`he export graphml`](commands/export.md#he-export-graphml)** — Export pairwise `<edge>` and N-ary `<hyperedge>` GraphML
 - **[`he export csv`](commands/export.md#he-export-csv)** — Export nodes/edges as CSV tables
 
 ### Management

--- a/docs/zh/cli/commands/export.md
+++ b/docs/zh/cli/commands/export.md
@@ -146,6 +146,7 @@ he export graphml KA_PATH -o FILE.graphml
 | 选项 | 别名 | 默认值 | 说明 |
 |--------|-------|---------|-------------|
 | `--output` | `-o` | *(必填)* | 输出 GraphML 文件 |
+| `--force` | `-f` | `false` | 覆盖已存在的非空 GraphML 文件 |
 
 ### 说明
 
@@ -153,6 +154,7 @@ he export graphml KA_PATH -o FILE.graphml
 - **N 元超边。** 3 个及以上端点的边写成 `<hyperedge>`，并按 `incident_nodes_extractor` 的返回顺序写出 `<endpoint node="…"/>`。端点不会被排序。
 - **属性。** 节点 / 边 `model_dump()` 中的标量字段（`str` / `int` / `float` / `bool`）成为 GraphML `<data>` 键。嵌套值转为字符串。XML 特殊字符（`& < > " '`）会被转义。
 - **悬空边。** 源或目标节点缺失的二元边（或任一端点缺失的超边）会被跳过（并记录 warning），不会导致崩溃。
+- **0/1 个端点的边。** 端点少于两个的边会被跳过并记录 warning。本导出不会发明一元 GraphML 编码。
 
 支持的 Auto-Type：`AutoGraph`、`AutoHypergraph` 及其时空子类。非图谱类型（`AutoList`、`AutoSet`、`AutoModel`）不支持。
 

--- a/docs/zh/cli/index.md
+++ b/docs/zh/cli/index.md
@@ -33,7 +33,7 @@ he --version
 | `he parse` | 从文档提取知识 | `-t` 模板, `-o` 输出, `-l` 语言, `--source` 来源标注 |
 | `he show` | 可视化知识图谱 | — |
 | `he export obsidian` | 导出为 Obsidian 知识库 | `-o` 输出, `--name`, `-f` 强制 |
-| `he export graphml` | 将二元图导出为 GraphML | `-o` 输出文件 |
+| `he export graphml` | 导出二元 `<edge>` 与 N 元 `<hyperedge>` GraphML | `-o` 输出文件, `-f` 强制 |
 | `he export csv` | 将节点/边导出为 CSV 表 | `-o` 目录, `-f` 强制 |
 | `he search` | 知识库语义搜索 | `-n` top-k 结果数, `--source`, `--tag` |
 | `he talk` | 与知识库对话 | `-i` 交互模式, `-q` 查询 |
@@ -172,7 +172,7 @@ he show ./output/
 - **[`he talk`](commands/talk.md)** — 与知识库对话
 - **[`he info`](commands/info.md)** — 查看知识库统计信息
 - **[`he export obsidian`](commands/export.md)** — 导出为 Obsidian 知识库
-- **[`he export graphml`](commands/export.md#he-export-graphml)** — 将二元图导出为 GraphML
+- **[`he export graphml`](commands/export.md#he-export-graphml)** — 导出二元 `<edge>` 与 N 元 `<hyperedge>` GraphML
 - **[`he export csv`](commands/export.md#he-export-csv)** — 将节点/边导出为 CSV 表
 
 ### 管理

--- a/hyperextract/cli/cli.py
+++ b/hyperextract/cli/cli.py
@@ -145,7 +145,7 @@ def main(
                     ),
                     (
                         "he export graphml <ka_path> -o <file>",
-                        "Export pairwise graph to GraphML",
+                        "pairwise <edge> + N-ary hyperedge",
                     ),
                     (
                         "he export csv <ka_path> -o <dir>",
@@ -594,6 +594,9 @@ def _is_hypergraph_ka(ka) -> bool:
 def export_graphml_cmd(
     ka_path: str = typer.Argument(..., help="Knowledge Abstract directory"),
     output: str = typer.Option(..., "--output", "-o", help="Output GraphML file"),
+    force: bool = typer.Option(
+        False, "--force", "-f", help="Overwrite an existing GraphML file"
+    ),
 ):
     """Export a knowledge graph to GraphML.
 
@@ -604,9 +607,20 @@ def export_graphml_cmd(
 
     logger.info("command=export-graphml ka_path=%s output=%s", ka_path, output)
 
-    ka, _path, template = _load_graph_ka_for_export(ka_path)
-
     output_path = Path(output)
+    existing_nonempty = (
+        output_path.exists()
+        and output_path.is_file()
+        and output_path.stat().st_size > 0
+    )
+    if existing_nonempty and not force:
+        console.print(
+            "[red]Error:[/red] Output file already exists. "
+            "Use --force / -f to overwrite it."
+        )
+        raise typer.Exit(1)
+
+    ka, _path, template = _load_graph_ka_for_export(ka_path)
     console.print(f"[blue]Knowledge Abstract:[/blue] {ka_path}")
     console.print(f"[blue]Template:[/blue] {template}")
     console.print(f"[blue]Output file:[/blue] {output}")

--- a/hyperextract/cli/cli.py
+++ b/hyperextract/cli/cli.py
@@ -145,7 +145,7 @@ def main(
                     ),
                     (
                         "he export graphml <ka_path> -o <file>",
-                        "pairwise <edge> + N-ary hyperedge",
+                        "pairwise <edge> + <hyperedge>",
                     ),
                     (
                         "he export csv <ka_path> -o <dir>",

--- a/tests/cli/test_verbose.py
+++ b/tests/cli/test_verbose.py
@@ -126,6 +126,8 @@ class TestCLINoVerboseFlag:
         assert "he tag" in result.output
         assert "he remove" in result.output
         assert "he clean" in result.output
+        assert "hyperedge" in result.output
+        assert "pairwise" in result.output
 
     def test_info_missing_ka_exits_with_error(self):
         """he info <nonexistent> exits with error."""

--- a/tests/utils/test_exporters.py
+++ b/tests/utils/test_exporters.py
@@ -432,6 +432,25 @@ class TestCLIExport:
         assert (out / "hyperedges.csv").exists()
         assert not (out / "edges.csv").exists()
 
+    def test_graphml_requires_force_for_existing_file(self, tmp_path):
+        ka_dir = _ka_dir(tmp_path)
+        dest = tmp_path / "out.graphml"
+        dest.write_text("KEEP-ME", encoding="utf-8")
+        fake = FakeGraphKA([Entity(name="A")], [])
+        with (
+            patch("hyperextract.cli.cli.validate_config"),
+            patch(
+                "hyperextract.cli.cli.get_template_from_ka", return_value=("t", "en")
+            ),
+            patch("hyperextract.cli.cli.Template.create", return_value=fake),
+        ):
+            result = runner.invoke(
+                app, ["export", "graphml", str(ka_dir), "-o", str(dest)]
+            )
+        assert result.exit_code != 0
+        assert "--force" in result.output or "-f" in result.output
+        assert dest.read_text(encoding="utf-8") == "KEEP-ME"
+
     def test_csv_requires_force_for_nonempty_dir(self, tmp_path):
         ka_dir = _ka_dir(tmp_path)
         dest = tmp_path / "csv_out"


### PR DESCRIPTION
## Summary
- `he export graphml` now refuses an existing non-empty target unless `--force` / `-f` is passed, matching csv/obsidian.
- The no-arg banner and bilingual CLI index mention pairwise `<edge>` plus N-ary hyperedge GraphML.
- Export docs note that 0/1-endpoint edges are skipped with a warning (no new unary encoding).

Closes #122

## Out of scope
- Deleting `GraphMLHypergraphError`
- Changing `<hyperedge>` encoding
- CSV exporter changes

## Test plan
- [x] `uv run pytest tests/utils/test_exporters.py tests/cli/ -q`
- [x] Existing GraphML file without `--force` exits non-zero and keeps its contents
