### PR TITLE
fix: include method templates in MCP list_templates

### DIFF
--- a/hyperextract/mcp_server.py
+++ b/hyperextract/mcp_server.py
@@ -82,14 +82,18 @@ def _dump(obj: Any) -> str:
 # ---------------------------------------------------------------------------
 
 
-def list_templates() -> str:
+def list_templates(include_methods: bool = True) -> str:
     """List the available knowledge-extraction templates.
+
+    Args:
+        include_methods: When true (default), include ``method/<name>``
+            entries the CLI lists and ``he parse -t`` accepts.
 
     Returns a JSON array of {name, type, description}.
     """
     from hyperextract.utils.template_engine import Template
 
-    templates = Template.list(include_methods=False)
+    templates = Template.list(include_methods=include_methods)
     out = []
     for name, cfg in sorted(templates.items()):
         desc = getattr(cfg, "description", "") or ""

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -59,6 +59,19 @@ def test_list_templates_returns_json():
     assert {"name", "type", "description"} <= set(out[0].keys())
 
 
+def test_list_templates_includes_methods_by_default():
+    out = json.loads(mcp_server.list_templates())
+    names = {item["name"] for item in out}
+    assert any(name.startswith("method/") for name in names)
+    assert "method/graph_rag" in names or "method/chunk_rag" in names
+
+
+def test_list_templates_can_hide_methods():
+    out = json.loads(mcp_server.list_templates(include_methods=False))
+    names = {item["name"] for item in out}
+    assert all(not name.startswith("method/") for name in names)
+
+
 # ---------------------------------------------------------------------------
 # info (no client needed — reads json directly)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- MCP `list_templates` now defaults to `include_methods=True`, matching `he list template`.
- Method names use `method/<name>` keys from `list_method_cfgs` (same ids as `he parse -t`).
- Callers can pass `include_methods=false` to hide methods.

Closes #132

## Out of scope
- Gallery changes
- MCP parse tool

## Test plan
- [x] `uv run pytest tests/test_mcp_server.py -q`
- [x] Default JSON includes at least one `method/` name
